### PR TITLE
feat: check-in card stack with swipe UI, backfill & session summary

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -178,9 +178,20 @@ All stores follow the `useBuildStore` pattern. DB writes are fire-and-forget `.c
 - **Streak algorithm:** Walk backward from today through scheduled days only. If today is scheduled but unchecked, start from yesterday. Count consecutive scheduled days with checkins; stop at first miss. Weekday habits skip weekends, custom habits skip non-custom days.
 - **Streak implementation:** `src/lib/streak-utils.ts` — pure `calculateStreak(habit, checkIns)` function.
 - **Category visuals:** `src/config/habit-categories.ts` — Lucide icon + hex color per `HabitCategory`.
-- **UI pattern:** Bottom sheet (HabitList z-300) triggered by FAB (z-90, bottom-right). Form (z-310) slides over list. Archive confirmation is a centered modal (z-320). Habit components use **Tailwind utility classes** (build components use inline styles).
+- **UI pattern:** Bottom sheet (HabitList z-300) triggered by FAB (z-90, bottom-right) or gear icon in CheckInScreen. Form (z-310) slides over list. Archive confirmation is a centered modal (z-320). Habit components use **Tailwind utility classes** (build components use inline styles).
 - **Onboarding:** Detected via `db.playerProfile.count() === 0` in AppInitializer. Two steps: welcome → habit suggestions (3 hardcoded defaults). After completion, triggers TutorialOverlay (z-500) with 3 coach marks. State in `gameStore.showOnboarding` / `gameStore.tutorialStep` (not persisted to DB).
 - **Build toggle:** Cog button (bottom-left, z-90) toggles `currentMode` between 'view' and 'build'. BuildToolbar only renders in build mode. Close button (top-right) also exits build mode.
+
+### Check-In System
+
+- **Entry points:** FAB button (bottom-right, z-90) opens `gameStore.activeScreen = 'check-in'`; auto-opens on app launch if pending habits exist and not suppressed.
+- **Component:** `src/components/CheckInScreen.tsx` (z-250) — full-screen overlay with date strip, swipe card stack, session summary.
+- **Date strip (backfill):** 7-day week strip (Mon–Sun). Past days tappable for backfill, future days disabled. Each tap reloads cards for that date.
+- **Swipe mechanics:** framer-motion `drag="x"` with no constraints (`dragMomentum={false}`). On release: 80px offset or 400px/s velocity triggers fly-off via `animate(x, ±screenWidth)`, otherwise springs back to center. Rotation follows drag via `useTransform`.
+- **Swipe right (complete):** Rolls surprise bonus, calculates reward via economy engine, persists check-in to DB, grants XP/coins, triggers celebration particles.
+- **Swipe left (skip):** Session-only dismiss — no DB record. Habit reappears on next check-in open.
+- **Session summary:** Shows habits completed, XP earned, coins earned. Perfect day bonus if all scheduled habits completed (race-free check using `sessionCompletedIds` + `initialCompletedIds`).
+- **Auto-open suppression:** "Don't auto-open today" checkbox sets `playerStore.dontShowCheckInToday` — checked in `AppInitializer`.
 
 ### Asset Folder Mapping (Penzilla Pack -> Repo)
 
@@ -203,9 +214,9 @@ All stores follow the `useBuildStore` pattern. DB writes are fire-and-forget `.c
 
 ## Current State
 
-**Last completed unit:** Issue #50 — Habit Management (CRUD + Onboarding)
-**What works:** Isometric grid, camera (pan/zoom/pinch/momentum), build system (drag-to-place, move, delete, undo, toggle via cog button), road auto-tiling (3 types), sidewalk auto-generation with accessories, IndexedDB persistence for all city state, habit CRUD UI (create/edit/archive forms, bottom sheet list, FAB entry point), streak calculation, first-time onboarding flow (welcome → habit suggestions → tutorial overlay), config loader (YAML→JSON→typed TS), economy data layer (player profile, inventory, placed assets, weekly snapshots), Zustand stores for player/habit/inventory/game state.
-**Next up:** Economy engine (XP/coin calculations, bonuses, level-ups)
+**Last completed unit:** Issue #51 — Check-In Card Stack, Backfill & Session Summary
+**What works:** Isometric grid, camera (pan/zoom/pinch/momentum), build system (drag-to-place, move, delete, undo, toggle via cog button), road auto-tiling (3 types), sidewalk auto-generation with accessories, IndexedDB persistence for all city state, habit CRUD UI (create/edit/archive forms, bottom sheet list, FAB entry point), streak calculation, first-time onboarding flow (welcome → habit suggestions → tutorial overlay), config loader (YAML→JSON→typed TS), economy data layer (player profile, inventory, placed assets, weekly snapshots), Zustand stores for player/habit/inventory/game state, economy engines (XP/coin calculations, bonuses, streaks, weekly snapshots), check-in card stack (swipe UI with framer-motion, backfill for current week, session summary with perfect day detection, auto-open on app launch).
+**Next up:** Reward reveal animations, level-up celebrations
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "dexie": "^4.3.0",
         "dexie-react-hooks": "^4.2.0",
+        "framer-motion": "^12.35.1",
         "lucide-react": "^0.577.0",
         "next": "16.1.6",
         "pixi.js": "^8.16.0",
@@ -3806,6 +3807,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.35.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.35.1.tgz",
+      "integrity": "sha512-rL8cLrjYZNShZqKV3U0Qj6Y5WDiZXYEM5giiTLfEqsIZxtspzMDCkKmrO5po76jWfvOg04+Vk+sfBvTD0iMmLw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.35.1",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5170,6 +5198,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.35.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.35.1.tgz",
+      "integrity": "sha512-7n6r7TtNOsH2UFSAXzTkfzOeO5616v9B178qBIjmu/WgEyJK0uqwytCEhwKBTuM/HJA40ptAw7hLFpxtPAMRZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "dexie": "^4.3.0",
     "dexie-react-hooks": "^4.2.0",
+    "framer-motion": "^12.35.1",
     "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "pixi.js": "^8.16.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,10 @@ const TutorialOverlay = dynamic(() => import('@/components/TutorialOverlay'), {
   ssr: false,
 });
 
+const CheckInScreen = dynamic(() => import('@/components/CheckInScreen'), {
+  ssr: false,
+});
+
 export default function Home() {
   return (
     <>
@@ -58,6 +62,7 @@ export default function Home() {
       <BuildToolbar />
       <BuildToggle />
       <HabitFab />
+      <CheckInScreen />
       <Onboarding />
       <TutorialOverlay />
     </>

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -6,6 +6,7 @@ import { usePlayerStore } from '@/stores/player-store';
 import { useHabitStore } from '@/stores/habit-store';
 import { useInventoryStore } from '@/stores/inventory-store';
 import { useGameStore } from '@/stores/game-store';
+import { formatDateString, isScheduledForDate } from '@/lib/schedule-utils';
 
 export default function AppInitializer() {
   useEffect(() => {
@@ -21,6 +22,26 @@ export default function AppInitializer() {
 
       if (isFirstUse) {
         useGameStore.getState().setShowOnboarding(true);
+        return;
+      }
+
+      // Auto-open check-in if there are pending habits and user hasn't dismissed
+      const today = formatDateString(new Date());
+      const playerState = usePlayerStore.getState();
+      if (playerState.dontShowCheckInToday === today) return;
+
+      const habits = useHabitStore.getState().habits;
+      const scheduled = habits.filter((h) => isScheduledForDate(h, today));
+      if (scheduled.length === 0) return;
+
+      const todayCheckIns = await db.checkIns.where('date').equals(today).toArray();
+      const checkedInIds = new Set(
+        todayCheckIns.filter((c) => c.completed || c.skipped).map((c) => c.habitId),
+      );
+      const hasPending = scheduled.some((h) => !checkedInIds.has(h.id));
+
+      if (hasPending) {
+        useGameStore.getState().openScreen('check-in');
       }
     }
     init();

--- a/src/components/CheckInScreen.tsx
+++ b/src/components/CheckInScreen.tsx
@@ -1,0 +1,675 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Settings, Flame, ChevronRight, ChevronLeft, Trophy, Sparkles, X } from 'lucide-react';
+import { motion, useMotionValue, useTransform, animate, AnimatePresence, type PanInfo } from 'framer-motion';
+import { useGameStore } from '@/stores/game-store';
+import { useHabitStore } from '@/stores/habit-store';
+import { usePlayerStore } from '@/stores/player-store';
+import { CATEGORY_META } from '@/config/habit-categories';
+import { isScheduledForDate, formatDateString } from '@/lib/schedule-utils';
+import { calculateCheckInReward, rollSurpriseBonus } from '@/lib/economy-engine';
+import { calculateStreak } from '@/lib/streak-utils';
+import { GAME_CONFIG } from '@/config/game-config';
+import { db } from '@/db/db';
+import type { Habit } from '@/types/habit';
+import type { CheckIn } from '@/types/check-in';
+import HabitList from './HabitList';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CardItem {
+  habit: Habit;
+  streak: number;
+  monthProgress: { done: number; total: number };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TIME_PRIORITY: Record<string, number> = {
+  morning: 0,
+  afternoon: 1,
+  evening: 2,
+  anytime: 3,
+};
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+function getWeekDates(today: Date): string[] {
+  const d = new Date(today);
+  d.setHours(0, 0, 0, 0);
+  const jsDay = d.getDay();
+  const mondayOffset = jsDay === 0 ? -6 : 1 - jsDay;
+  const monday = new Date(d);
+  monday.setDate(d.getDate() + mondayOffset);
+
+  const dates: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const day = new Date(monday);
+    day.setDate(monday.getDate() + i);
+    dates.push(formatDateString(day));
+  }
+  return dates;
+}
+
+function getMonthProgress(
+  habit: Habit,
+  selectedDate: string,
+  allCheckIns: CheckIn[],
+): { done: number; total: number } {
+  const [year, month] = selectedDate.split('-').map(Number);
+  const today = formatDateString(new Date());
+  const lastDay = selectedDate <= today ? selectedDate : today;
+
+  const completedSet = new Set(
+    allCheckIns.filter((c) => c.habitId === habit.id && c.completed).map((c) => c.date),
+  );
+
+  let total = 0;
+  let done = 0;
+  const d = new Date(year, month - 1, 1);
+  while (d.getMonth() === month - 1) {
+    const ds = formatDateString(d);
+    if (ds > lastDay) break;
+    if (isScheduledForDate(habit, ds)) {
+      total++;
+      if (completedSet.has(ds)) done++;
+    }
+    d.setDate(d.getDate() + 1);
+  }
+  return { done, total };
+}
+
+// ---------------------------------------------------------------------------
+// Celebration particles
+// ---------------------------------------------------------------------------
+
+function CelebrationBurst({ onDone }: { onDone: () => void }) {
+  const particles = useMemo(() => {
+    const colors = ['#10B981', '#F59E0B', '#8B5CF6', '#EC4899', '#3B82F6', '#EF4444'];
+    return Array.from({ length: 20 }, (_, i) => ({
+      id: i,
+      x: (Math.random() - 0.5) * 300,
+      y: -(Math.random() * 250 + 80),
+      rotate: Math.random() * 720 - 360,
+      scale: Math.random() * 0.6 + 0.4,
+      color: colors[Math.floor(Math.random() * colors.length)],
+    }));
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(onDone, 800);
+    return () => clearTimeout(t);
+  }, [onDone]);
+
+  return (
+    <div className="fixed inset-0 pointer-events-none" style={{ zIndex: 260 }}>
+      <div className="absolute left-1/2 top-1/2">
+        {particles.map((p) => (
+          <motion.div
+            key={p.id}
+            initial={{ x: 0, y: 0, scale: 1, opacity: 1 }}
+            animate={{
+              x: p.x,
+              y: p.y,
+              scale: p.scale,
+              opacity: 0,
+              rotate: p.rotate,
+            }}
+            transition={{ duration: 0.7, ease: 'easeOut' }}
+            className="absolute w-2.5 h-2.5 rounded-full"
+            style={{ backgroundColor: p.color }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function DateStrip({
+  weekDates,
+  selectedDate,
+  todayStr,
+  onSelect,
+}: {
+  weekDates: string[];
+  selectedDate: string;
+  todayStr: string;
+  onSelect: (date: string) => void;
+}) {
+  return (
+    <div className="flex gap-1.5 px-4 py-2">
+      {weekDates.map((date, i) => {
+        const isToday = date === todayStr;
+        const isFuture = date > todayStr;
+        const isSelected = date === selectedDate;
+        const dayNum = date.split('-')[2];
+
+        return (
+          <button
+            key={date}
+            onClick={() => onSelect(date)}
+            disabled={isFuture}
+            className={`flex-1 flex flex-col items-center py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              isSelected
+                ? 'bg-violet-600 text-white'
+                : isToday
+                  ? 'bg-violet-600/20 text-violet-300'
+                  : isFuture
+                    ? 'opacity-30 pointer-events-none text-gray-500'
+                    : 'text-gray-400 active:bg-gray-700'
+            }`}
+          >
+            <span className="text-[10px]">{DAY_LABELS[i]}</span>
+            <span className="text-sm">{parseInt(dayNum)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SwipeCard({
+  card,
+  onSwipeRight,
+  onSwipeLeft,
+}: {
+  card: CardItem;
+  onSwipeRight: () => void;
+  onSwipeLeft: () => void;
+}) {
+  const [exiting, setExiting] = useState(false);
+  const x = useMotionValue(0);
+  const rotate = useTransform(x, [-300, 0, 300], [-15, 0, 15]);
+  const rightOpacity = useTransform(x, [0, 100], [0, 1]);
+  const leftOpacity = useTransform(x, [-100, 0], [1, 0]);
+
+  const meta = CATEGORY_META[card.habit.category];
+  const Icon = meta.icon;
+
+  function handleDragEnd(_: unknown, info: PanInfo) {
+    if (exiting) return;
+
+    const offset = info.offset.x;
+    const velocity = info.velocity.x;
+
+    const SWIPE_PX = 80;
+    const SWIPE_VEL = 400;
+
+    if (offset > SWIPE_PX || velocity > SWIPE_VEL) {
+      setExiting(true);
+      animate(x, window.innerWidth + 100, {
+        type: 'tween',
+        duration: 0.2,
+        ease: 'easeOut',
+      }).then(onSwipeRight);
+    } else if (offset < -SWIPE_PX || velocity < -SWIPE_VEL) {
+      setExiting(true);
+      animate(x, -(window.innerWidth + 100), {
+        type: 'tween',
+        duration: 0.2,
+        ease: 'easeOut',
+      }).then(onSwipeLeft);
+    } else {
+      // Snap back to center
+      animate(x, 0, { type: 'spring', stiffness: 500, damping: 30 });
+    }
+  }
+
+  return (
+    <motion.div
+      style={{ x, rotate }}
+      drag="x"
+      dragMomentum={false}
+      onDragEnd={handleDragEnd}
+      className="absolute inset-0 touch-none"
+    >
+      <div className="h-full rounded-2xl bg-gray-800 border border-gray-700 px-6 py-8 flex flex-col items-center justify-center relative overflow-hidden select-none">
+        {/* Swipe indicators */}
+        <motion.div
+          style={{ opacity: rightOpacity }}
+          className="absolute top-4 left-4 px-3 py-1 rounded-full bg-emerald-500/20 border border-emerald-500 text-emerald-400 text-sm font-bold"
+        >
+          DONE
+        </motion.div>
+        <motion.div
+          style={{ opacity: leftOpacity }}
+          className="absolute top-4 right-4 px-3 py-1 rounded-full bg-gray-500/20 border border-gray-500 text-gray-400 text-sm font-bold"
+        >
+          SKIP
+        </motion.div>
+
+        {/* Category icon */}
+        <div
+          className="w-16 h-16 rounded-2xl flex items-center justify-center mb-4"
+          style={{ background: meta.color + '22' }}
+        >
+          <Icon size={32} color={meta.color} />
+        </div>
+
+        {/* Difficulty badge */}
+        <span
+          className="text-xs font-semibold px-2.5 py-1 rounded-full mb-3"
+          style={{ background: meta.color + '22', color: meta.color }}
+        >
+          {card.habit.difficulty.charAt(0).toUpperCase() + card.habit.difficulty.slice(1)}
+        </span>
+
+        {/* Habit name */}
+        <h3 className="text-xl font-bold text-white text-center mb-4">{card.habit.name}</h3>
+
+        {/* Monthly progress */}
+        <p className="text-sm text-gray-400 mb-2">
+          {card.monthProgress.done}/{card.monthProgress.total} this month
+        </p>
+
+        {/* Streak */}
+        {card.streak > 0 && (
+          <div className="flex items-center gap-1 text-orange-400">
+            <Flame size={16} />
+            <span className="text-sm font-semibold">{card.streak} day streak</span>
+          </div>
+        )}
+
+        {/* Swipe hints */}
+        <div className="absolute bottom-4 left-0 right-0 flex justify-between px-6 text-xs text-gray-500">
+          <div className="flex items-center gap-1">
+            <ChevronLeft size={14} />
+            <span>Skip</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span>Done</span>
+            <ChevronRight size={14} />
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  );
+}
+
+function SessionSummary({
+  completed,
+  total,
+  xp,
+  coins,
+  perfectDay,
+  onReturn,
+}: {
+  completed: number;
+  total: number;
+  xp: number;
+  coins: number;
+  perfectDay: boolean;
+  onReturn: () => void;
+}) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+      {perfectDay && (
+        <div className="flex items-center gap-2 mb-4 text-yellow-400">
+          <Trophy size={24} />
+          <span className="text-lg font-bold">Perfect check-in!</span>
+          <Trophy size={24} />
+        </div>
+      )}
+
+      <h2 className="text-2xl font-bold text-white mb-6">Session Complete</h2>
+
+      <div className="space-y-3 mb-8 w-full max-w-[240px]">
+        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
+          <span className="text-gray-400 text-sm">Habits completed</span>
+          <span className="text-white font-bold">{completed}/{total}</span>
+        </div>
+        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
+          <span className="text-gray-400 text-sm">XP earned</span>
+          <span className="text-emerald-400 font-bold">+{xp}</span>
+        </div>
+        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
+          <span className="text-gray-400 text-sm">Coins earned</span>
+          <span className="text-yellow-400 font-bold">+{coins}</span>
+        </div>
+      </div>
+
+      <button
+        onClick={onReturn}
+        className="px-8 py-3 rounded-xl bg-violet-600 text-white font-semibold active:bg-violet-700 transition-colors"
+      >
+        Return to City
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+export default function CheckInScreen() {
+  const activeScreen = useGameStore((s) => s.activeScreen);
+  const firstWeekBoostActive = useGameStore((s) => s.firstWeekBoostActive);
+  const doubleXPEventActive = useGameStore((s) => s.doubleXPEventActive);
+  const openScreen = useGameStore((s) => s.openScreen);
+  const queueReward = useGameStore((s) => s.queueReward);
+
+  const habits = useHabitStore((s) => s.habits);
+  const habitCheckIn = useHabitStore((s) => s.checkIn);
+  const getScheduledForDate = useHabitStore((s) => s.getScheduledForDate);
+
+  const addXP = usePlayerStore((s) => s.addXP);
+  const addCoins = usePlayerStore((s) => s.addCoins);
+  const dontShowCheckInToday = usePlayerStore((s) => s.dontShowCheckInToday);
+  const setDontShowCheckInToday = usePlayerStore((s) => s.setDontShowCheckInToday);
+
+  const todayStr = useMemo(() => formatDateString(new Date()), []);
+  const weekDates = useMemo(() => getWeekDates(new Date()), []);
+
+  const [selectedDate, setSelectedDate] = useState(todayStr);
+  const [cards, setCards] = useState<CardItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [sessionXP, setSessionXP] = useState(0);
+  const [sessionCoins, setSessionCoins] = useState(0);
+  const [sessionCompleted, setSessionCompleted] = useState(0);
+  const [sessionTotal, setSessionTotal] = useState(0);
+  const [showSummary, setShowSummary] = useState(false);
+  const [showHabitList, setShowHabitList] = useState(false);
+  const [sessionCompletedIds, setSessionCompletedIds] = useState<Set<string>>(new Set());
+  const [initialCompletedIds, setInitialCompletedIds] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [perfectDay, setPerfectDay] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
+
+  // Load cards when date or habits change
+  const loadCards = useCallback(
+    async (date: string) => {
+      setLoading(true);
+      const scheduled = getScheduledForDate(date);
+      const checkIns = await db.checkIns.where('date').equals(date).toArray();
+      const allCheckIns = await db.checkIns.toArray();
+
+      // Only filter out habits with completed check-ins (not skipped — skip is session-only)
+      const completedIds = new Set(
+        checkIns.filter((c) => c.completed).map((c) => c.habitId),
+      );
+
+      setInitialCompletedIds(completedIds);
+
+      const pending = scheduled.filter((h) => !completedIds.has(h.id));
+
+      // Build check-ins by habit for streak calculation
+      const byHabit: Record<string, CheckIn[]> = {};
+      for (const ci of allCheckIns) {
+        (byHabit[ci.habitId] ??= []).push(ci);
+      }
+
+      const cardItems: CardItem[] = pending
+        .map((habit) => ({
+          habit,
+          streak: calculateStreak(habit, byHabit[habit.id] ?? []),
+          monthProgress: getMonthProgress(habit, date, allCheckIns),
+        }))
+        .sort((a, b) => {
+          const timeDiff =
+            (TIME_PRIORITY[a.habit.timeOfDay] ?? 3) - (TIME_PRIORITY[b.habit.timeOfDay] ?? 3);
+          if (timeDiff !== 0) return timeDiff;
+          return a.habit.sortOrder - b.habit.sortOrder;
+        });
+
+      setCards(cardItems);
+      setCurrentIndex(0);
+      setSessionXP(0);
+      setSessionCoins(0);
+      setSessionCompleted(0);
+      setSessionTotal(scheduled.length);
+      setSessionCompletedIds(new Set());
+      setPerfectDay(false);
+
+      if (cardItems.length === 0) {
+        const alreadyCompleted = completedIds.size;
+        setSessionCompleted(alreadyCompleted);
+        setShowSummary(true);
+      } else {
+        setShowSummary(false);
+      }
+
+      setLoading(false);
+    },
+    [getScheduledForDate],
+  );
+
+  useEffect(() => {
+    if (activeScreen === 'check-in') {
+      loadCards(selectedDate);
+    }
+  }, [activeScreen, selectedDate, habits, loadCards]);
+
+  const handleDateSelect = useCallback((date: string) => {
+    setSelectedDate(date);
+  }, []);
+
+  const finishSession = useCallback(
+    (completedIds: Set<string>) => {
+      const allCompletedIds = new Set([...initialCompletedIds, ...completedIds]);
+      const scheduled = getScheduledForDate(selectedDate);
+      const isPerfect =
+        scheduled.length > 0 && scheduled.every((h) => allCompletedIds.has(h.id));
+
+      if (isPerfect) {
+        const perfectXP = GAME_CONFIG.bonuses.daily_perfect.xp;
+        const perfectCoins = GAME_CONFIG.bonuses.daily_perfect.coins;
+        addXP(perfectXP);
+        addCoins(perfectCoins);
+        setSessionXP((s) => s + perfectXP);
+        setSessionCoins((s) => s + perfectCoins);
+        setPerfectDay(true);
+      }
+
+      setShowSummary(true);
+    },
+    [initialCompletedIds, getScheduledForDate, selectedDate, addXP, addCoins],
+  );
+
+  const handleSwipeRight = useCallback(() => {
+    const card = cards[currentIndex];
+    if (!card) return;
+
+    const surprise = rollSurpriseBonus();
+    const reward = calculateCheckInReward(card.habit.difficulty, {
+      surpriseBonus: surprise,
+      firstWeekActive: firstWeekBoostActive,
+      doubleXPActive: doubleXPEventActive,
+    });
+
+    habitCheckIn(card.habit.id, selectedDate, reward.xp, reward.coins);
+    addXP(reward.xp);
+    addCoins(reward.coins);
+
+    if (surprise) {
+      queueReward({
+        type: 'surprise-bonus',
+        payload: {
+          xp: reward.breakdown.surpriseBonusXP,
+          coins: reward.breakdown.surpriseBonusCoins,
+          habitName: card.habit.name,
+        },
+      });
+    }
+
+    const newCompletedIds = new Set(sessionCompletedIds);
+    newCompletedIds.add(card.habit.id);
+
+    setSessionXP((s) => s + reward.xp);
+    setSessionCoins((s) => s + reward.coins);
+    setSessionCompleted((s) => s + 1);
+    setSessionCompletedIds(newCompletedIds);
+
+    // Celebration burst
+    setShowCelebration(true);
+
+    const nextIndex = currentIndex + 1;
+    if (nextIndex >= cards.length) {
+      finishSession(newCompletedIds);
+    } else {
+      setCurrentIndex(nextIndex);
+    }
+  }, [
+    cards,
+    currentIndex,
+    selectedDate,
+    firstWeekBoostActive,
+    doubleXPEventActive,
+    habitCheckIn,
+    addXP,
+    addCoins,
+    queueReward,
+    sessionCompletedIds,
+    finishSession,
+  ]);
+
+  const handleSwipeLeft = useCallback(() => {
+    // Skip = dismiss from this session only, no DB record
+    const nextIndex = currentIndex + 1;
+    if (nextIndex >= cards.length) {
+      finishSession(sessionCompletedIds);
+    } else {
+      setCurrentIndex(nextIndex);
+    }
+  }, [currentIndex, cards.length, sessionCompletedIds, finishSession]);
+
+  const handleClose = useCallback(() => {
+    openScreen('city');
+  }, [openScreen]);
+
+  const handleDontShowToggle = useCallback(() => {
+    if (dontShowCheckInToday === todayStr) {
+      setDontShowCheckInToday(null);
+    } else {
+      setDontShowCheckInToday(todayStr);
+    }
+  }, [dontShowCheckInToday, todayStr, setDontShowCheckInToday]);
+
+  if (activeScreen !== 'check-in') return null;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-gray-950 flex flex-col"
+        style={{ zIndex: 250 }}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 pt-4 pb-1">
+          <h1 className="text-lg font-bold text-white">Check-In</h1>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setShowHabitList(true)}
+              className="p-2 text-gray-400 active:text-white"
+              aria-label="Manage habits"
+            >
+              <Settings size={20} />
+            </button>
+            <button
+              onClick={handleClose}
+              className="p-2 text-gray-400 active:text-white"
+              aria-label="Close check-in"
+            >
+              <X size={20} />
+            </button>
+          </div>
+        </div>
+
+        {/* Date strip */}
+        <DateStrip
+          weekDates={weekDates}
+          selectedDate={selectedDate}
+          todayStr={todayStr}
+          onSelect={handleDateSelect}
+        />
+
+        {/* Card area */}
+        {loading ? (
+          <div className="flex-1 flex items-center justify-center">
+            <div className="text-gray-500 text-sm">Loading...</div>
+          </div>
+        ) : showSummary ? (
+          <SessionSummary
+            completed={sessionCompleted}
+            total={sessionTotal}
+            xp={sessionXP}
+            coins={sessionCoins}
+            perfectDay={perfectDay}
+            onReturn={handleClose}
+          />
+        ) : (
+          <div className="flex-1 flex flex-col px-4 pt-2 pb-2 min-h-0">
+            {/* Counter */}
+            <p className="text-xs text-gray-500 mb-2 text-center shrink-0">
+              {currentIndex + 1} / {cards.length}
+            </p>
+
+            {/* Card stack — fills remaining space */}
+            <div className="relative flex-1 min-h-0">
+              {/* Peek card */}
+              {currentIndex + 1 < cards.length && (
+                <div className="absolute inset-0 rounded-2xl bg-gray-800 border border-gray-700 scale-[0.97] opacity-60" />
+              )}
+
+              {/* Active card */}
+              {cards[currentIndex] && (
+                <SwipeCard
+                  key={cards[currentIndex].habit.id}
+                  card={cards[currentIndex]}
+                  onSwipeRight={handleSwipeRight}
+                  onSwipeLeft={handleSwipeLeft}
+                />
+              )}
+            </div>
+
+            {/* Accumulated rewards */}
+            <div className="shrink-0 h-8 flex items-center justify-center gap-4 text-sm">
+              {sessionXP > 0 && (
+                <div className="flex items-center gap-1">
+                  <Sparkles size={14} className="text-emerald-400" />
+                  <span className="text-emerald-400 font-semibold">+{sessionXP} XP</span>
+                </div>
+              )}
+              {sessionCoins > 0 && (
+                <span className="text-yellow-400 font-semibold">+{sessionCoins} coins</span>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Don't show today checkbox */}
+        {selectedDate === todayStr && (
+          <div className="px-4 pb-4 pt-1 shrink-0">
+            <label className="flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={dontShowCheckInToday === todayStr}
+                onChange={handleDontShowToggle}
+                className="w-3.5 h-3.5 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-0 focus:ring-offset-0"
+              />
+              Don&apos;t auto-open today
+            </label>
+          </div>
+        )}
+      </div>
+
+      {/* Celebration burst */}
+      <AnimatePresence>
+        {showCelebration && (
+          <CelebrationBurst onDone={() => setShowCelebration(false)} />
+        )}
+      </AnimatePresence>
+
+      {/* HabitList overlay */}
+      {showHabitList && <HabitList onClose={() => setShowHabitList(false)} />}
+    </>
+  );
+}

--- a/src/components/HabitFab.tsx
+++ b/src/components/HabitFab.tsx
@@ -1,30 +1,25 @@
 'use client';
 
-import { useState } from 'react';
 import { ClipboardList } from 'lucide-react';
 import { useGameStore } from '@/stores/game-store';
-import HabitList from './HabitList';
 
 export default function HabitFab() {
-  const [open, setOpen] = useState(false);
   const currentMode = useGameStore((s) => s.currentMode);
+  const activeScreen = useGameStore((s) => s.activeScreen);
   const showOnboarding = useGameStore((s) => s.showOnboarding);
   const initialized = useGameStore((s) => s.initialized);
+  const openScreen = useGameStore((s) => s.openScreen);
 
-  if (!initialized || currentMode === 'build' || showOnboarding) return null;
+  if (!initialized || currentMode === 'build' || showOnboarding || activeScreen === 'check-in') return null;
 
   return (
-    <>
-      <button
-        onClick={() => setOpen(true)}
-        className="fixed bottom-6 right-4 w-14 h-14 rounded-full bg-violet-600 text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform"
-        style={{ zIndex: 90 }}
-        aria-label="Manage habits"
-      >
-        <ClipboardList size={24} />
-      </button>
-
-      {open && <HabitList onClose={() => setOpen(false)} />}
-    </>
+    <button
+      onClick={() => openScreen('check-in')}
+      className="fixed bottom-6 right-4 w-14 h-14 rounded-full bg-violet-600 text-white flex items-center justify-center shadow-lg active:scale-95 transition-transform"
+      style={{ zIndex: 90 }}
+      aria-label="Check in habits"
+    >
+      <ClipboardList size={24} />
+    </button>
   );
 }

--- a/src/stores/habit-store.ts
+++ b/src/stores/habit-store.ts
@@ -25,7 +25,7 @@ interface HabitState {
   createHabit: (data: Omit<Habit, 'id' | 'sortOrder' | 'archived' | 'createdAt' | 'updatedAt'>) => string;
   updateHabit: (id: string, data: Partial<Omit<Habit, 'id' | 'createdAt' | 'updatedAt'>>) => void;
   archiveHabit: (id: string) => void;
-  checkIn: (habitId: string, date: string) => CheckIn;
+  checkIn: (habitId: string, date: string, xpEarned?: number, coinsEarned?: number) => CheckIn;
   skipHabit: (habitId: string, date: string) => CheckIn;
   getScheduledForDate: (date: string) => Habit[];
   getCheckInsForDate: (date: string) => Promise<CheckIn[]>;
@@ -84,7 +84,7 @@ export const useHabitStore = create<HabitState>((set, get) => ({
     db.habits.update(id, { archived: 1 as unknown as boolean, updatedAt: now }).catch(() => {});
   },
 
-  checkIn: (habitId, date) => {
+  checkIn: (habitId, date, xpEarned = 0, coinsEarned = 0) => {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
     const checkIn: CheckIn = {
@@ -93,8 +93,8 @@ export const useHabitStore = create<HabitState>((set, get) => ({
       date,
       completed: true,
       skipped: false,
-      xpEarned: 0,
-      coinsEarned: 0,
+      xpEarned,
+      coinsEarned,
       createdAt: now,
       updatedAt: now,
     };


### PR DESCRIPTION
## Summary
- Tinder-style swipe card stack for daily habit check-ins with framer-motion drag gestures (swipe right = complete, swipe left = session-only skip)
- Week-long backfill via date strip (Mon–today), session summary with perfect day detection and celebration particles
- Auto-opens on app launch when pending habits exist; FAB now opens check-in screen directly

Closes #51

## Test plan
- [x] Create 3+ habits with different timeOfDay/difficulty/category
- [x] Tap FAB → check-in screen opens with cards sorted correctly
- [x] Swipe right → card flies off right, XP/coins accumulate, celebration particles fire
- [x] Swipe left → card dismissed, no reward, habit still shows on next open
- [x] After all cards → session summary shows correct totals
- [x] "Return to City" → back to city view
- [x] Tap gear icon → HabitList opens on top
- [x] Date strip → tap a past day, see that day's pending habits (backfill)
- [x] "Don't auto-open today" checkbox → suppress auto-open
- [x] Auto-open → with pending habits, check-in opens on app launch
- [x] X button closes check-in screen
- [x] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)