### PR TITLE
feat: reward celebrations & check-in reward flow (#52)

### DIFF
--- a/src/components/CheckInScreen.tsx
+++ b/src/components/CheckInScreen.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useLayoutEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
 import { Settings, Flame, ChevronRight, ChevronLeft, Check, Trophy, Sparkles, X } from 'lucide-react';
 import { motion, useMotionValue, useTransform, animate, AnimatePresence, type PanInfo, type MotionValue } from 'framer-motion';
 import { useGameStore } from '@/stores/game-store';
@@ -8,9 +8,12 @@ import { useHabitStore } from '@/stores/habit-store';
 import { usePlayerStore } from '@/stores/player-store';
 import { CATEGORY_META } from '@/config/habit-categories';
 import { isScheduledForDate, formatDateString } from '@/lib/schedule-utils';
-import { calculateCheckInReward, rollSurpriseBonus } from '@/lib/economy-engine';
+import { calculateCheckInReward, rollSurpriseBonus, rollDoubleXPEvent } from '@/lib/economy-engine';
+import { checkStreakMilestone } from '@/lib/streak-engine';
+import { detectLevelUps } from '@/lib/leveling-engine';
 import { calculateStreak } from '@/lib/streak-utils';
 import { GAME_CONFIG } from '@/config/game-config';
+import { ASSET_CATALOG } from '@/config/asset-catalog';
 import { db } from '@/db/db';
 import type { Habit } from '@/types/habit';
 import type { CheckIn } from '@/types/check-in';
@@ -127,6 +130,87 @@ function CelebrationBurst({ onDone }: { onDone: () => void }) {
         ))}
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fly-to-HUD reward animation
+// ---------------------------------------------------------------------------
+
+function RewardFloat({
+  xp,
+  coins,
+  isSurpriseBonus,
+}: {
+  xp: number;
+  coins: number;
+  isSurpriseBonus: boolean;
+}) {
+  const [phase, setPhase] = useState<'appear' | 'pulse' | 'fly'>('appear');
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setPhase('pulse'), 200);
+    const t2 = setTimeout(() => setPhase('fly'), 1200);
+    return () => { clearTimeout(t1); clearTimeout(t2); };
+  }, []);
+
+  return (
+    <motion.div
+      className="fixed left-0 right-0 flex justify-center pointer-events-none"
+      style={{ top: '35%', zIndex: 270 }}
+      initial={{ opacity: 0, scale: 0.3, y: 20 }}
+      animate={
+        phase === 'fly'
+          ? { opacity: 0, scale: 0.2, y: -350, x: -100 }
+          : { opacity: 1, scale: 1, y: 0, x: 0 }
+      }
+      transition={
+        phase === 'fly'
+          ? { duration: 0.6, ease: [0.4, 0, 0.2, 1] }
+          : { type: 'spring', stiffness: 300, damping: 15, mass: 0.8 }
+      }
+    >
+      <div className="flex flex-col items-center gap-2">
+        {isSurpriseBonus && (
+          <motion.span
+            className="text-amber-300 font-black text-base tracking-widest uppercase"
+            style={{ textShadow: '0 0 20px rgba(251, 191, 36, 0.6), 0 0 40px rgba(251, 191, 36, 0.3)' }}
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.15, duration: 0.3 }}
+          >
+            Surprise Bonus!
+          </motion.span>
+        )}
+        <motion.div
+          className="flex items-center gap-4 px-6 py-3 rounded-2xl"
+          style={{
+            background: 'radial-gradient(ellipse at center, rgba(16,185,129,0.15) 0%, transparent 70%)',
+          }}
+          animate={
+            phase === 'pulse'
+              ? { scale: [1, 1.08, 1], transition: { duration: 0.5, ease: 'easeInOut' } }
+              : {}
+          }
+        >
+          <div className="flex items-center gap-1.5">
+            <Sparkles size={22} className="text-emerald-400" />
+            <span
+              className="text-emerald-300 font-extrabold text-2xl"
+              style={{ textShadow: '0 0 16px rgba(16,185,129,0.5), 0 2px 4px rgba(0,0,0,0.3)' }}
+            >
+              +{xp} XP
+            </span>
+          </div>
+          <span
+            className="text-yellow-300 font-extrabold text-2xl"
+            style={{ textShadow: '0 0 16px rgba(252,211,77,0.5), 0 2px 4px rgba(0,0,0,0.3)' }}
+          >
+            +{coins} &#x1FA99;
+          </span>
+        </motion.div>
+      </div>
+    </motion.div>
   );
 }
 
@@ -357,6 +441,8 @@ export default function CheckInScreen() {
   const doubleXPEventActive = useGameStore((s) => s.doubleXPEventActive);
   const openScreen = useGameStore((s) => s.openScreen);
   const queueReward = useGameStore((s) => s.queueReward);
+  const setDeferLevelUps = useGameStore((s) => s.setDeferLevelUps);
+  const setDoubleXPEvent = useGameStore((s) => s.setDoubleXPEvent);
 
   const habits = useHabitStore((s) => s.habits);
   const habitCheckIn = useHabitStore((s) => s.checkIn);
@@ -385,6 +471,9 @@ export default function CheckInScreen() {
   const [perfectDay, setPerfectDay] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
+  const [rewardFloatKey, setRewardFloatKey] = useState(0);
+  const [rewardFloatData, setRewardFloatData] = useState<{ xp: number; coins: number; isSurpriseBonus: boolean } | null>(null);
+  const sessionStartXPRef = useRef(0);
 
   // Shared motion value for the front card (drives back-card responsive animation)
   const frontX = useMotionValue(0);
@@ -463,6 +552,21 @@ export default function CheckInScreen() {
     }
   }, [activeScreen, selectedDate, habits, loadCards]);
 
+  // Session mount: defer level-ups, roll 2x XP, capture start XP
+  useEffect(() => {
+    if (activeScreen === 'check-in') {
+      setDeferLevelUps(true);
+      sessionStartXPRef.current = usePlayerStore.getState().xp;
+      if (rollDoubleXPEvent()) {
+        setDoubleXPEvent(true);
+      }
+      return () => {
+        setDeferLevelUps(false);
+        setDoubleXPEvent(false);
+      };
+    }
+  }, [activeScreen, setDeferLevelUps, setDoubleXPEvent]);
+
   const handleDateSelect = useCallback((date: string) => {
     setSelectedDate(date);
   }, []);
@@ -482,11 +586,27 @@ export default function CheckInScreen() {
         setSessionXP((s) => s + perfectXP);
         setSessionCoins((s) => s + perfectCoins);
         setPerfectDay(true);
+        queueReward({
+          type: 'daily-perfect',
+          payload: { xp: perfectXP, coins: perfectCoins },
+        });
       }
 
+      // Detect deferred level-ups across the entire session
+      const currentXP = usePlayerStore.getState().xp;
+      const levelResult = detectLevelUps(sessionStartXPRef.current, currentXP, ASSET_CATALOG);
+      if (levelResult.levelsGained.length > 0) {
+        queueReward({
+          type: 'level-up',
+          payload: { level: levelResult.newLevel, unlockedAssets: levelResult.unlockedAssets },
+        });
+      }
+
+      // Re-capture start XP for the next date session (deferLevelUps stays true until screen closes)
+      sessionStartXPRef.current = usePlayerStore.getState().xp;
       setShowSummary(true);
     },
-    [initialCompletedIds, getScheduledForDate, selectedDate, addXP, addCoins],
+    [initialCompletedIds, getScheduledForDate, selectedDate, addXP, addCoins, queueReward],
   );
 
   const handleSwipeRight = useCallback(() => {
@@ -504,14 +624,17 @@ export default function CheckInScreen() {
     addXP(reward.xp);
     addCoins(reward.coins);
 
-    if (surprise) {
+    // Fly-to-HUD animation (replaces surprise-bonus overlay + inline text)
+    setRewardFloatData({ xp: reward.xp, coins: reward.coins, isSurpriseBonus: surprise });
+    setRewardFloatKey((k) => k + 1);
+
+    // Streak milestone detection
+    const newStreak = card.streak + 1;
+    const milestone = checkStreakMilestone(newStreak);
+    if (milestone !== null) {
       queueReward({
-        type: 'surprise-bonus',
-        payload: {
-          xp: reward.breakdown.surpriseBonusXP,
-          coins: reward.breakdown.surpriseBonusCoins,
-          habitName: card.habit.name,
-        },
+        type: 'streak-milestone',
+        payload: { streak: newStreak, habitName: card.habit.name },
       });
     }
 
@@ -597,7 +720,7 @@ export default function CheckInScreen() {
         style={{ zIndex: 250 }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 pt-4 pb-1">
+        <div className="flex items-center justify-between px-4 pb-1" style={{ paddingTop: 'max(1rem, env(safe-area-inset-top))' }}>
           <h1 className="text-lg font-bold text-white">Check-In</h1>
           <div className="flex items-center gap-1">
             <button
@@ -624,6 +747,18 @@ export default function CheckInScreen() {
           todayStr={todayStr}
           onSelect={handleDateSelect}
         />
+
+        {/* Event banners */}
+        {doubleXPEventActive && (
+          <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-amber-500/20 border border-amber-500/40 text-center">
+            <span className="text-amber-400 font-bold text-sm">&#x26A1; 2x XP Active!</span>
+          </div>
+        )}
+        {firstWeekBoostActive && (
+          <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-violet-500/20 border border-violet-500/40 text-center">
+            <span className="text-violet-300 font-bold text-sm">&#x1F680; 2x XP BOOST — First Week!</span>
+          </div>
+        )}
 
         {/* Card area */}
         {loading ? (
@@ -709,18 +844,8 @@ export default function CheckInScreen() {
               </button>
             </div>
 
-            {/* Accumulated rewards */}
-            <div className="shrink-0 h-8 flex items-center justify-center gap-4 text-sm">
-              {sessionXP > 0 && (
-                <div className="flex items-center gap-1">
-                  <Sparkles size={14} className="text-emerald-400" />
-                  <span className="text-emerald-400 font-semibold">+{sessionXP} XP</span>
-                </div>
-              )}
-              {sessionCoins > 0 && (
-                <span className="text-yellow-400 font-semibold">+{sessionCoins} coins</span>
-              )}
-            </div>
+            {/* Spacer for layout balance */}
+            <div className="shrink-0 h-4" />
           </div>
         )}
 
@@ -744,6 +869,18 @@ export default function CheckInScreen() {
       <AnimatePresence>
         {showCelebration && (
           <CelebrationBurst onDone={() => setShowCelebration(false)} />
+        )}
+      </AnimatePresence>
+
+      {/* Fly-to-HUD reward animation */}
+      <AnimatePresence mode="wait">
+        {rewardFloatData && (
+          <RewardFloat
+            key={rewardFloatKey}
+            xp={rewardFloatData.xp}
+            coins={rewardFloatData.coins}
+            isSurpriseBonus={rewardFloatData.isSurpriseBonus}
+          />
         )}
       </AnimatePresence>
 

--- a/src/components/RewardReveal.tsx
+++ b/src/components/RewardReveal.tsx
@@ -142,6 +142,32 @@ function StreakMilestoneContent({ payload }: { payload: PendingReward['payload']
   );
 }
 
+function DailyPerfectContent({ payload }: { payload: PendingReward['payload'] }) {
+  const xp = payload.xp as number | undefined;
+  const coins = payload.coins as number | undefined;
+
+  return (
+    <div className="reward-scale-in" style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 12 }}>
+      <div style={{ fontSize: 48, lineHeight: 1 }}>🏆</div>
+      <div style={{ fontSize: 14, fontWeight: 500, color: 'rgba(255,255,255,0.7)' }}>
+        PERFECT DAY!
+      </div>
+      <div style={{ display: 'flex', gap: 16 }}>
+        {xp && (
+          <div style={{ fontSize: 28, fontWeight: 700, color: '#A78BFA' }}>
+            +{xp} XP
+          </div>
+        )}
+        {coins && (
+          <div style={{ fontSize: 28, fontWeight: 700, color: '#FCD34D' }}>
+            +{coins} &#x1FA99;
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function AssetUnlockContent({ payload }: { payload: PendingReward['payload'] }) {
   const asset = payload.asset as CatalogAsset | undefined;
 
@@ -187,6 +213,8 @@ function RewardContent({ reward }: { reward: PendingReward }) {
       return <WeeklyBonusContent payload={reward.payload} />;
     case 'streak-milestone':
       return <StreakMilestoneContent payload={reward.payload} />;
+    case 'daily-perfect':
+      return <DailyPerfectContent payload={reward.payload} />;
     case 'asset-unlock':
       return <AssetUnlockContent payload={reward.payload} />;
     default:

--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -7,6 +7,7 @@ interface GameState {
   currentMode: GameMode;
   activeScreen: ActiveScreen;
   pendingRewards: PendingReward[];
+  deferLevelUps: boolean;
   doubleXPEventActive: boolean;
   firstWeekBoostActive: boolean;
   showOnboarding: boolean;
@@ -18,6 +19,7 @@ interface GameState {
   openScreen: (screen: ActiveScreen) => void;
   queueReward: (reward: PendingReward) => void;
   dequeueReward: () => PendingReward | undefined;
+  setDeferLevelUps: (defer: boolean) => void;
   setDoubleXPEvent: (active: boolean) => void;
   setShowOnboarding: (show: boolean) => void;
   setTutorialStep: (step: number | null) => void;
@@ -27,6 +29,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   currentMode: 'view',
   activeScreen: 'city',
   pendingRewards: [],
+  deferLevelUps: false,
   doubleXPEventActive: false,
   firstWeekBoostActive: false,
   showOnboarding: false,
@@ -77,6 +80,10 @@ export const useGameStore = create<GameState>((set, get) => ({
     const [first, ...rest] = state.pendingRewards;
     set({ pendingRewards: rest });
     return first;
+  },
+
+  setDeferLevelUps: (defer) => {
+    set({ deferLevelUps: defer });
   },
 
   setDoubleXPEvent: (active) => {

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -104,10 +104,12 @@ export const usePlayerStore = create<PlayerState>((set, get) => ({
         });
       }
       import('@/stores/game-store').then(({ useGameStore }) => {
-        useGameStore.getState().queueReward({
-          type: 'level-up',
-          payload: { level: newLevel, unlockedAssets: result.unlockedAssets },
-        });
+        if (!useGameStore.getState().deferLevelUps) {
+          useGameStore.getState().queueReward({
+            type: 'level-up',
+            payload: { level: newLevel, unlockedAssets: result.unlockedAssets },
+          });
+        }
       });
     }
 

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -3,6 +3,6 @@ export type GameMode = 'view' | 'build' | 'check-in';
 export type ActiveScreen = 'city' | 'check-in' | 'stats' | 'shop' | 'settings';
 
 export interface PendingReward {
-  type: 'level-up' | 'asset-unlock' | 'surprise-bonus' | 'weekly-bonus' | 'streak-milestone';
+  type: 'level-up' | 'asset-unlock' | 'surprise-bonus' | 'weekly-bonus' | 'streak-milestone' | 'daily-perfect';
   payload: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- **Fly-to-HUD reward animation**: XP/coins spring in at center, pulse, then fly up toward HUD with glow effects. Surprise bonus shown inline with golden label instead of separate overlay.
- **Deferred level-ups**: Level-up overlays no longer interrupt mid-session card flow — queued and shown after all cards are done/skipped.
- **Daily-perfect overlay**: New "PERFECT DAY!" RewardReveal variant with trophy icon, shown at session end before level-up.
- **Streak milestone wiring**: `checkStreakMilestone()` called after each check-in, queues overlay on milestone hit.
- **2x XP event banner**: Random roll on session mount (~21%), amber banner between date strip and cards.
- **First-week boost banner**: Violet banner when within first 7 days of use.
- **Safe-area inset**: Header respects `env(safe-area-inset-top)` so it doesn't collide with mobile status bar in portrait.

Closes #52

## Test plan
- [x] Swipe right on a habit → glowing XP+coins text springs in, pulses, flies to top-left
- [x] Surprise bonus → "Surprise Bonus!" golden label above amounts in same animation
- [x] Level-up during card flow does NOT show overlay mid-session
- [x] Complete all cards → daily-perfect overlay → deferred level-up → session summary
- [x] Streak milestone (7/14/30 days) → streak overlay after check-in
- [ ] 2x XP banner appears ~21% of sessions
- [x] First-week boost banner shows if within 7 days
- [x] Header doesn't collide with status bar on mobile
- [x] Switching dates after session end doesn't re-trigger level-up overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)