### PR TITLE
feat: weekly view for check-in screen (#72)

### DIFF
--- a/src/components/CheckInScreen.tsx
+++ b/src/components/CheckInScreen.tsx
@@ -1,46 +1,17 @@
 'use client';
 
-import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
-import { Settings, Flame, ChevronRight, ChevronLeft, Check, Trophy, Sparkles, X } from 'lucide-react';
-import { motion, useMotionValue, useTransform, animate, AnimatePresence, type PanInfo, type MotionValue } from 'framer-motion';
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { Settings, X } from 'lucide-react';
 import { useGameStore } from '@/stores/game-store';
-import { useHabitStore } from '@/stores/habit-store';
-import { usePlayerStore } from '@/stores/player-store';
-import { CATEGORY_META } from '@/config/habit-categories';
-import { isScheduledForDate, formatDateString } from '@/lib/schedule-utils';
-import { calculateCheckInReward, rollSurpriseBonus, rollDoubleXPEvent } from '@/lib/economy-engine';
-import { checkStreakMilestone } from '@/lib/streak-engine';
-import { detectLevelUps } from '@/lib/leveling-engine';
-import { calculateStreak } from '@/lib/streak-utils';
-import { GAME_CONFIG } from '@/config/game-config';
-import { ASSET_CATALOG } from '@/config/asset-catalog';
-import { db } from '@/db/db';
-import type { Habit } from '@/types/habit';
-import type { CheckIn } from '@/types/check-in';
+import { rollDoubleXPEvent } from '@/lib/economy-engine';
+import { formatDateString } from '@/lib/schedule-utils';
+import DailyView from './DailyView';
+import WeeklyView from './WeeklyView';
 import HabitList from './HabitList';
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-interface CardItem {
-  habit: Habit;
-  streak: number;
-  monthProgress: { done: number; total: number };
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const TIME_PRIORITY: Record<string, number> = {
-  morning: 0,
-  afternoon: 1,
-  evening: 2,
-  anytime: 3,
-};
-
-const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
 function getWeekDates(today: Date): string[] {
   const d = new Date(today);
@@ -59,662 +30,44 @@ function getWeekDates(today: Date): string[] {
   return dates;
 }
 
-function getMonthProgress(
-  habit: Habit,
-  selectedDate: string,
-  allCheckIns: CheckIn[],
-): { done: number; total: number } {
-  const [year, month] = selectedDate.split('-').map(Number);
-  const today = formatDateString(new Date());
-  const lastDay = selectedDate <= today ? selectedDate : today;
-
-  const completedSet = new Set(
-    allCheckIns.filter((c) => c.habitId === habit.id && c.completed).map((c) => c.date),
-  );
-
-  let total = 0;
-  let done = 0;
-  const d = new Date(year, month - 1, 1);
-  while (d.getMonth() === month - 1) {
-    const ds = formatDateString(d);
-    if (ds > lastDay) break;
-    if (isScheduledForDate(habit, ds)) {
-      total++;
-      if (completedSet.has(ds)) done++;
-    }
-    d.setDate(d.getDate() + 1);
-  }
-  return { done, total };
-}
-
-// ---------------------------------------------------------------------------
-// Celebration particles
-// ---------------------------------------------------------------------------
-
-function CelebrationBurst({ onDone }: { onDone: () => void }) {
-  const particles = useMemo(() => {
-    const colors = ['#10B981', '#F59E0B', '#8B5CF6', '#EC4899', '#3B82F6', '#EF4444'];
-    return Array.from({ length: 20 }, (_, i) => ({
-      id: i,
-      x: (Math.random() - 0.5) * 300,
-      y: -(Math.random() * 250 + 80),
-      rotate: Math.random() * 720 - 360,
-      scale: Math.random() * 0.6 + 0.4,
-      color: colors[Math.floor(Math.random() * colors.length)],
-    }));
-  }, []);
-
-  useEffect(() => {
-    const t = setTimeout(onDone, 800);
-    return () => clearTimeout(t);
-  }, [onDone]);
-
-  return (
-    <div className="fixed inset-0 pointer-events-none" style={{ zIndex: 260 }}>
-      <div className="absolute left-1/2 top-1/2">
-        {particles.map((p) => (
-          <motion.div
-            key={p.id}
-            initial={{ x: 0, y: 0, scale: 1, opacity: 1 }}
-            animate={{
-              x: p.x,
-              y: p.y,
-              scale: p.scale,
-              opacity: 0,
-              rotate: p.rotate,
-            }}
-            transition={{ duration: 0.7, ease: 'easeOut' }}
-            className="absolute w-2.5 h-2.5 rounded-full"
-            style={{ backgroundColor: p.color }}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Fly-to-HUD reward animation
-// ---------------------------------------------------------------------------
-
-function RewardFloat({
-  xp,
-  coins,
-  isSurpriseBonus,
-  onDone,
-}: {
-  xp: number;
-  coins: number;
-  isSurpriseBonus: boolean;
-  onDone?: () => void;
-}) {
-  const [phase, setPhase] = useState<'appear' | 'pulse' | 'fly'>('appear');
-
-  useEffect(() => {
-    const t1 = setTimeout(() => setPhase('pulse'), 200);
-    const t2 = setTimeout(() => setPhase('fly'), 1200);
-    const t3 = setTimeout(() => onDone?.(), 1800);
-    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  return (
-    <motion.div
-      className="fixed left-0 right-0 flex justify-center pointer-events-none"
-      style={{ top: '35%', zIndex: 270 }}
-      initial={{ opacity: 0, scale: 0.3, y: 20 }}
-      animate={
-        phase === 'fly'
-          ? { opacity: 0, scale: 0.2, y: -350, x: -100 }
-          : { opacity: 1, scale: 1, y: 0, x: 0 }
-      }
-      transition={
-        phase === 'fly'
-          ? { duration: 0.6, ease: [0.4, 0, 0.2, 1] }
-          : { type: 'spring', stiffness: 300, damping: 15, mass: 0.8 }
-      }
-    >
-      <div className="flex flex-col items-center gap-2">
-        {isSurpriseBonus && (
-          <motion.span
-            className="text-amber-300 font-black text-base tracking-widest uppercase"
-            style={{ textShadow: '0 0 20px rgba(251, 191, 36, 0.6), 0 0 40px rgba(251, 191, 36, 0.3)' }}
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.15, duration: 0.3 }}
-          >
-            Surprise Bonus!
-          </motion.span>
-        )}
-        <motion.div
-          className="flex items-center gap-4 px-6 py-3 rounded-2xl"
-          style={{
-            background: 'radial-gradient(ellipse at center, rgba(16,185,129,0.15) 0%, transparent 70%)',
-          }}
-          animate={
-            phase === 'pulse'
-              ? { scale: [1, 1.08, 1], transition: { duration: 0.5, ease: 'easeInOut' } }
-              : {}
-          }
-        >
-          <div className="flex items-center gap-1.5">
-            <Sparkles size={22} className="text-emerald-400" />
-            <span
-              className="text-emerald-300 font-extrabold text-2xl"
-              style={{ textShadow: '0 0 16px rgba(16,185,129,0.5), 0 2px 4px rgba(0,0,0,0.3)' }}
-            >
-              +{xp} XP
-            </span>
-          </div>
-          <span
-            className="text-yellow-300 font-extrabold text-2xl"
-            style={{ textShadow: '0 0 16px rgba(252,211,77,0.5), 0 2px 4px rgba(0,0,0,0.3)', display: 'inline-flex', alignItems: 'center', gap: 4 }}
-          >
-            +{coins} <img src="/assets/coin/coin.svg" alt="coin" style={{ width: 28, height: 28 }} />
-          </span>
-        </motion.div>
-      </div>
-    </motion.div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function DateStrip({
-  weekDates,
-  selectedDate,
-  todayStr,
-  onSelect,
-}: {
-  weekDates: string[];
-  selectedDate: string;
-  todayStr: string;
-  onSelect: (date: string) => void;
-}) {
-  return (
-    <div className="flex gap-1.5 px-4 py-2">
-      {weekDates.map((date, i) => {
-        const isToday = date === todayStr;
-        const isFuture = date > todayStr;
-        const isSelected = date === selectedDate;
-        const dayNum = date.split('-')[2];
-
-        return (
-          <button
-            key={date}
-            onClick={() => onSelect(date)}
-            disabled={isFuture}
-            className={`flex-1 flex flex-col items-center py-1.5 rounded-lg text-xs font-medium transition-colors ${
-              isSelected
-                ? 'bg-violet-600 text-white'
-                : isToday
-                  ? 'bg-violet-600/20 text-violet-300'
-                  : isFuture
-                    ? 'opacity-30 pointer-events-none text-gray-500'
-                    : 'text-gray-400 active:bg-gray-700'
-            }`}
-          >
-            <span className="text-[10px]">{DAY_LABELS[i]}</span>
-            <span className="text-sm">{parseInt(dayNum)}</span>
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function SwipeCard({
-  card,
-  x,
-  onSwipeRight,
-  onSwipeLeft,
-  onExitStart,
-  disabled,
-}: {
-  card: CardItem;
-  x: MotionValue<number>;
-  onSwipeRight: () => void;
-  onSwipeLeft: () => void;
-  onExitStart?: () => void;
-  disabled?: boolean;
-}) {
-  const [exiting, setExiting] = useState(false);
-  const rotate = useTransform(x, [-200, 0, 200], [-12, 0, 12]);
-  const doneOpacity = useTransform(x, [0, 60], [0, 1]);
-  const skipOpacity = useTransform(x, [-60, 0], [1, 0]);
-
-  const meta = CATEGORY_META[card.habit.category];
-  const Icon = meta.icon;
-
-  function handleDragEnd(_: unknown, info: PanInfo) {
-    if (exiting || disabled) return;
-
-    const { offset, velocity } = info;
-    const absX = Math.abs(offset.x);
-    const absVel = Math.abs(velocity.x);
-
-    // Multi-tier swipe detection for natural mobile feel:
-    // 1. Dragged past 50px in either direction
-    // 2. Quick flick (>250px/s) regardless of distance
-    // 3. Short deliberate swipe (>25px AND >100px/s)
-    const triggered =
-      absX > 50 || absVel > 250 || (absX > 25 && absVel > 100);
-
-    if (!triggered) {
-      animate(x, 0, { type: 'spring', stiffness: 600, damping: 30 });
-      return;
-    }
-
-    setExiting(true);
-    onExitStart?.();
-
-    const direction = offset.x > 0 ? 1 : -1;
-    // Faster flick → faster exit animation (min 0.1s, max 0.25s)
-    const duration = Math.max(0.1, Math.min(0.25, 150 / Math.max(absVel, 200)));
-
-    animate(x, direction * (window.innerWidth + 200), {
-      type: 'tween',
-      duration,
-      ease: 'easeOut',
-    }).then(() => {
-      if (direction === 1) onSwipeRight();
-      else onSwipeLeft();
-    });
-  }
-
-  return (
-    <motion.div
-      style={{ x, rotate, willChange: 'transform' }}
-      drag={!exiting && !disabled ? 'x' : false}
-      dragMomentum={false}
-      onDragEnd={handleDragEnd}
-      className="absolute inset-0 touch-none"
-    >
-      <div className="h-full rounded-2xl bg-gray-800 border border-gray-700 px-6 py-8 flex flex-col items-center justify-center relative overflow-hidden select-none">
-        {/* Swipe indicators */}
-        <motion.div
-          style={{ opacity: doneOpacity }}
-          className="absolute top-4 left-4 px-3 py-1 rounded-full bg-emerald-500/20 border-2 border-emerald-500 text-emerald-400 text-sm font-bold"
-        >
-          DONE
-        </motion.div>
-        <motion.div
-          style={{ opacity: skipOpacity }}
-          className="absolute top-4 right-4 px-3 py-1 rounded-full bg-gray-500/20 border-2 border-gray-500 text-gray-400 text-sm font-bold"
-        >
-          SKIP
-        </motion.div>
-
-        {/* Category icon */}
-        <div
-          className="w-16 h-16 rounded-2xl flex items-center justify-center mb-4"
-          style={{ background: meta.color + '22' }}
-        >
-          <Icon size={32} color={meta.color} />
-        </div>
-
-        {/* Difficulty badge */}
-        <span
-          className="text-xs font-semibold px-2.5 py-1 rounded-full mb-3"
-          style={{ background: meta.color + '22', color: meta.color }}
-        >
-          {card.habit.difficulty.charAt(0).toUpperCase() + card.habit.difficulty.slice(1)}
-        </span>
-
-        {/* Habit name */}
-        <h3 className="text-xl font-bold text-white text-center mb-4">{card.habit.name}</h3>
-
-        {/* Monthly progress */}
-        <p className="text-sm text-gray-400 mb-2">
-          {card.monthProgress.done}/{card.monthProgress.total} this month
-        </p>
-
-        {/* Streak */}
-        {card.streak > 0 && (
-          <div className="flex items-center gap-1 text-orange-400">
-            <Flame size={16} />
-            <span className="text-sm font-semibold">{card.streak} day streak</span>
-          </div>
-        )}
-      </div>
-    </motion.div>
-  );
-}
-
-function SessionSummary({
-  completed,
-  total,
-  xp,
-  coins,
-  perfectDay,
-  onReturn,
-}: {
-  completed: number;
-  total: number;
-  xp: number;
-  coins: number;
-  perfectDay: boolean;
-  onReturn: () => void;
-}) {
-  return (
-    <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
-      {perfectDay && (
-        <div className="flex items-center gap-2 mb-4 text-yellow-400">
-          <Trophy size={24} />
-          <span className="text-lg font-bold">Perfect check-in!</span>
-          <Trophy size={24} />
-        </div>
-      )}
-
-      <h2 className="text-2xl font-bold text-white mb-6">Session Complete</h2>
-
-      <div className="space-y-3 mb-8 w-full max-w-[240px]">
-        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
-          <span className="text-gray-400 text-sm">Habits completed</span>
-          <span className="text-white font-bold">{completed}/{total}</span>
-        </div>
-        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
-          <span className="text-gray-400 text-sm">XP earned</span>
-          <span className="text-emerald-400 font-bold">+{xp}</span>
-        </div>
-        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
-          <span className="text-gray-400 text-sm">Coins earned</span>
-          <span className="text-yellow-400 font-bold">+{coins}</span>
-        </div>
-      </div>
-
-      <button
-        onClick={onReturn}
-        className="px-8 py-3 rounded-xl bg-violet-600 text-white font-semibold active:bg-violet-700 transition-colors"
-      >
-        Return to City
-      </button>
-    </div>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Main Component
 // ---------------------------------------------------------------------------
 
 export default function CheckInScreen() {
   const activeScreen = useGameStore((s) => s.activeScreen);
-  const firstWeekBoostActive = useGameStore((s) => s.firstWeekBoostActive);
-  const doubleXPEventActive = useGameStore((s) => s.doubleXPEventActive);
   const openScreen = useGameStore((s) => s.openScreen);
-  const queueReward = useGameStore((s) => s.queueReward);
   const setDeferLevelUps = useGameStore((s) => s.setDeferLevelUps);
   const setDoubleXPEvent = useGameStore((s) => s.setDoubleXPEvent);
-
-  const habits = useHabitStore((s) => s.habits);
-  const habitCheckIn = useHabitStore((s) => s.checkIn);
-  const getScheduledForDate = useHabitStore((s) => s.getScheduledForDate);
-
-  const addXP = usePlayerStore((s) => s.addXP);
-  const addCoins = usePlayerStore((s) => s.addCoins);
-  const dontShowCheckInToday = usePlayerStore((s) => s.dontShowCheckInToday);
-  const setDontShowCheckInToday = usePlayerStore((s) => s.setDontShowCheckInToday);
 
   const todayStr = useMemo(() => formatDateString(new Date()), []);
   const weekDates = useMemo(() => getWeekDates(new Date()), []);
 
+  const [activeTab, setActiveTab] = useState<'daily' | 'weekly'>('daily');
   const [selectedDate, setSelectedDate] = useState(todayStr);
-  const [cards, setCards] = useState<CardItem[]>([]);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [sessionXP, setSessionXP] = useState(0);
-  const [sessionCoins, setSessionCoins] = useState(0);
-  const [sessionCompleted, setSessionCompleted] = useState(0);
-  const [sessionTotal, setSessionTotal] = useState(0);
-  const [showSummary, setShowSummary] = useState(false);
   const [showHabitList, setShowHabitList] = useState(false);
-  const [sessionCompletedIds, setSessionCompletedIds] = useState<Set<string>>(new Set());
-  const [initialCompletedIds, setInitialCompletedIds] = useState<Set<string>>(new Set());
-  const [loading, setLoading] = useState(true);
-  const [perfectDay, setPerfectDay] = useState(false);
-  const [showCelebration, setShowCelebration] = useState(false);
-  const [isAnimating, setIsAnimating] = useState(false);
-  const [rewardFloatKey, setRewardFloatKey] = useState(0);
-  const [rewardFloatData, setRewardFloatData] = useState<{ xp: number; coins: number; isSurpriseBonus: boolean } | null>(null);
-  const sessionStartXPRef = useRef(0);
 
-  // Shared motion value for the front card (drives back-card responsive animation)
-  const frontX = useMotionValue(0);
-  const backScale = useTransform(frontX, (v) => 0.95 + Math.min(Math.abs(v) / 150, 1) * 0.05);
-  const backOpacity = useTransform(frontX, (v) => 0.6 + Math.min(Math.abs(v) / 150, 1) * 0.4);
-
-  // Reset shared motion value when the active card changes (before paint to avoid flash)
-  useLayoutEffect(() => {
-    frontX.set(0);
-    setIsAnimating(false);
-  }, [currentIndex, frontX]);
-
-  // Load cards when date or habits change
-  const loadCards = useCallback(
-    async (date: string) => {
-      setLoading(true);
-      const scheduled = getScheduledForDate(date);
-      const checkIns = await db.checkIns.where('date').equals(date).toArray();
-      const allCheckIns = await db.checkIns.toArray();
-
-      // Only filter out habits with completed check-ins (not skipped — skip is session-only)
-      const completedIds = new Set(
-        checkIns.filter((c) => c.completed).map((c) => c.habitId),
-      );
-
-      setInitialCompletedIds(completedIds);
-
-      const pending = scheduled.filter((h) => !completedIds.has(h.id));
-
-      // Build check-ins by habit for streak calculation
-      const byHabit: Record<string, CheckIn[]> = {};
-      for (const ci of allCheckIns) {
-        (byHabit[ci.habitId] ??= []).push(ci);
-      }
-
-      const cardItems: CardItem[] = pending
-        .map((habit) => ({
-          habit,
-          streak: calculateStreak(habit, byHabit[habit.id] ?? []),
-          monthProgress: getMonthProgress(habit, date, allCheckIns),
-        }))
-        .sort((a, b) => {
-          const timeDiff =
-            (TIME_PRIORITY[a.habit.timeOfDay] ?? 3) - (TIME_PRIORITY[b.habit.timeOfDay] ?? 3);
-          if (timeDiff !== 0) return timeDiff;
-          return a.habit.sortOrder - b.habit.sortOrder;
-        });
-
-      setCards(cardItems);
-      setCurrentIndex(0);
-      setSessionXP(0);
-      setSessionCoins(0);
-      setSessionCompleted(0);
-      setSessionTotal(scheduled.length);
-      setSessionCompletedIds(new Set());
-      setPerfectDay(false);
-      setIsAnimating(false);
-      frontX.set(0);
-
-      if (cardItems.length === 0) {
-        const alreadyCompleted = completedIds.size;
-        setSessionCompleted(alreadyCompleted);
-        setShowSummary(true);
-      } else {
-        setShowSummary(false);
-      }
-
-      setLoading(false);
-    },
-    [getScheduledForDate],
-  );
-
+  // Session lifecycle: defer level-ups, roll 2x XP event
   useEffect(() => {
-    if (activeScreen === 'check-in') {
-      loadCards(selectedDate);
+    setDeferLevelUps(true);
+    if (rollDoubleXPEvent()) {
+      setDoubleXPEvent(true);
     }
-  }, [activeScreen, selectedDate, habits, loadCards]);
-
-  // Session mount: defer level-ups, roll 2x XP, capture start XP
-  useEffect(() => {
-    if (activeScreen === 'check-in') {
-      setDeferLevelUps(true);
-      sessionStartXPRef.current = usePlayerStore.getState().xp;
-      if (rollDoubleXPEvent()) {
-        setDoubleXPEvent(true);
-      }
-      return () => {
-        setDeferLevelUps(false);
-        setDoubleXPEvent(false);
-      };
-    }
-  }, [activeScreen, setDeferLevelUps, setDoubleXPEvent]);
-
-  const handleDateSelect = useCallback((date: string) => {
-    setSelectedDate(date);
-  }, []);
-
-  const finishSession = useCallback(
-    (completedIds: Set<string>) => {
-      const allCompletedIds = new Set([...initialCompletedIds, ...completedIds]);
-      const scheduled = getScheduledForDate(selectedDate);
-      const isPerfect =
-        scheduled.length > 0 && scheduled.every((h) => allCompletedIds.has(h.id));
-
-      if (isPerfect) {
-        const perfectXP = GAME_CONFIG.bonuses.daily_perfect.xp;
-        const perfectCoins = GAME_CONFIG.bonuses.daily_perfect.coins;
-        addXP(perfectXP);
-        addCoins(perfectCoins);
-        setSessionXP((s) => s + perfectXP);
-        setSessionCoins((s) => s + perfectCoins);
-        setPerfectDay(true);
-        queueReward({
-          type: 'daily-perfect',
-          payload: { xp: perfectXP, coins: perfectCoins },
-        });
-      }
-
-      // Detect deferred level-ups across the entire session
-      const currentXP = usePlayerStore.getState().xp;
-      const levelResult = detectLevelUps(sessionStartXPRef.current, currentXP, ASSET_CATALOG);
-      if (levelResult.levelsGained.length > 0) {
-        queueReward({
-          type: 'level-up',
-          payload: { level: levelResult.newLevel, unlockedAssets: levelResult.unlockedAssets },
-        });
-      }
-
-      // Re-capture start XP for the next date session (deferLevelUps stays true until screen closes)
-      sessionStartXPRef.current = usePlayerStore.getState().xp;
-      setShowSummary(true);
-    },
-    [initialCompletedIds, getScheduledForDate, selectedDate, addXP, addCoins, queueReward],
-  );
-
-  const handleSwipeRight = useCallback(() => {
-    const card = cards[currentIndex];
-    if (!card) return;
-
-    const surprise = rollSurpriseBonus();
-    const reward = calculateCheckInReward(card.habit.difficulty, {
-      surpriseBonus: surprise,
-      firstWeekActive: firstWeekBoostActive,
-      doubleXPActive: doubleXPEventActive,
-    });
-
-    habitCheckIn(card.habit.id, selectedDate, reward.xp, reward.coins);
-    addXP(reward.xp);
-    addCoins(reward.coins);
-
-    // Fly-to-HUD animation (replaces surprise-bonus overlay + inline text)
-    setRewardFloatData({ xp: reward.xp, coins: reward.coins, isSurpriseBonus: surprise });
-    setRewardFloatKey((k) => k + 1);
-
-    // Streak milestone detection
-    const newStreak = card.streak + 1;
-    const milestone = checkStreakMilestone(newStreak);
-    if (milestone !== null) {
-      queueReward({
-        type: 'streak-milestone',
-        payload: { streak: newStreak, habitName: card.habit.name },
-      });
-    }
-
-    const newCompletedIds = new Set(sessionCompletedIds);
-    newCompletedIds.add(card.habit.id);
-
-    setSessionXP((s) => s + reward.xp);
-    setSessionCoins((s) => s + reward.coins);
-    setSessionCompleted((s) => s + 1);
-    setSessionCompletedIds(newCompletedIds);
-
-    // Celebration burst
-    setShowCelebration(true);
-
-    const nextIndex = currentIndex + 1;
-    if (nextIndex >= cards.length) {
-      finishSession(newCompletedIds);
-    } else {
-      setCurrentIndex(nextIndex);
-    }
-  }, [
-    cards,
-    currentIndex,
-    selectedDate,
-    firstWeekBoostActive,
-    doubleXPEventActive,
-    habitCheckIn,
-    addXP,
-    addCoins,
-    queueReward,
-    sessionCompletedIds,
-    finishSession,
-  ]);
-
-  const handleSwipeLeft = useCallback(() => {
-    // Skip = dismiss from this session only, no DB record
-    const nextIndex = currentIndex + 1;
-    if (nextIndex >= cards.length) {
-      finishSession(sessionCompletedIds);
-    } else {
-      setCurrentIndex(nextIndex);
-    }
-  }, [currentIndex, cards.length, sessionCompletedIds, finishSession]);
-
-  const handleTapDone = useCallback(() => {
-    if (isAnimating) return;
-    setIsAnimating(true);
-    animate(frontX, window.innerWidth + 200, {
-      type: 'tween',
-      duration: 0.25,
-      ease: 'easeOut',
-    }).then(handleSwipeRight);
-  }, [isAnimating, frontX, handleSwipeRight]);
-
-  const handleTapSkip = useCallback(() => {
-    if (isAnimating) return;
-    setIsAnimating(true);
-    animate(frontX, -(window.innerWidth + 200), {
-      type: 'tween',
-      duration: 0.25,
-      ease: 'easeOut',
-    }).then(handleSwipeLeft);
-  }, [isAnimating, frontX, handleSwipeLeft]);
+    return () => {
+      setDeferLevelUps(false);
+      setDoubleXPEvent(false);
+    };
+  }, [setDeferLevelUps, setDoubleXPEvent]);
 
   const handleClose = useCallback(() => {
-    setRewardFloatData(null);
-    setShowCelebration(false);
     openScreen('city');
   }, [openScreen]);
 
-  const handleDontShowToggle = useCallback(() => {
-    if (dontShowCheckInToday === todayStr) {
-      setDontShowCheckInToday(null);
-    } else {
-      setDontShowCheckInToday(todayStr);
-    }
-  }, [dontShowCheckInToday, todayStr, setDontShowCheckInToday]);
+  // Weekly view: tap day header → switch to daily tab with that date
+  const handleSelectDay = useCallback((date: string) => {
+    setSelectedDate(date);
+    setActiveTab('daily');
+  }, []);
 
   if (activeScreen !== 'check-in') return null;
 
@@ -745,152 +98,49 @@ export default function CheckInScreen() {
           </div>
         </div>
 
-        {/* Date strip */}
-        <DateStrip
-          weekDates={weekDates}
-          selectedDate={selectedDate}
-          todayStr={todayStr}
-          onSelect={handleDateSelect}
-        />
+        {/* Tab toggle */}
+        <div className="flex mx-4 mb-1 rounded-lg bg-gray-800/50 p-1">
+          <button
+            onClick={() => setActiveTab('daily')}
+            className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              activeTab === 'daily'
+                ? 'bg-violet-600 text-white'
+                : 'text-gray-400'
+            }`}
+          >
+            Daily
+          </button>
+          <button
+            onClick={() => setActiveTab('weekly')}
+            className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              activeTab === 'weekly'
+                ? 'bg-violet-600 text-white'
+                : 'text-gray-400'
+            }`}
+          >
+            Weekly
+          </button>
+        </div>
 
-        {/* Event banners */}
-        {doubleXPEventActive && (
-          <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-amber-500/20 border border-amber-500/40 text-center">
-            <span className="text-amber-400 font-bold text-sm">&#x26A1; 2x XP Active!</span>
-          </div>
-        )}
-        {firstWeekBoostActive && (
-          <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-violet-500/20 border border-violet-500/40 text-center">
-            <span className="text-violet-300 font-bold text-sm">&#x1F680; 2x XP BOOST — First Week!</span>
-          </div>
-        )}
-
-        {/* Card area */}
-        {loading ? (
-          <div className="flex-1 flex items-center justify-center">
-            <div className="text-gray-500 text-sm">Loading...</div>
-          </div>
-        ) : showSummary ? (
-          <SessionSummary
-            completed={sessionCompleted}
-            total={sessionTotal}
-            xp={sessionXP}
-            coins={sessionCoins}
-            perfectDay={perfectDay}
-            onReturn={handleClose}
+        {/* Tab content */}
+        {activeTab === 'daily' ? (
+          <DailyView
+            weekDates={weekDates}
+            todayStr={todayStr}
+            selectedDate={selectedDate}
+            onSelectDate={setSelectedDate}
+            onClose={handleClose}
           />
         ) : (
-          <div className="flex-1 flex flex-col px-4 pt-2 pb-2 min-h-0">
-            {/* Counter */}
-            <p className="text-xs text-gray-500 mb-2 text-center shrink-0">
-              {currentIndex + 1} / {cards.length}
-            </p>
-
-            {/* Card stack — fills remaining space */}
-            <div className="relative flex-1 min-h-0 touch-none">
-              {/* Next card (behind, responds to front card drag) */}
-              {currentIndex + 1 < cards.length && (
-                <motion.div
-                  className="absolute inset-0 rounded-2xl bg-gray-800 border border-gray-700 pointer-events-none overflow-hidden"
-                  style={{ scale: backScale, opacity: backOpacity }}
-                >
-                  {(() => {
-                    const next = cards[currentIndex + 1];
-                    const nextMeta = CATEGORY_META[next.habit.category];
-                    const NextIcon = nextMeta.icon;
-                    return (
-                      <div className="h-full flex flex-col items-center justify-center px-6 select-none">
-                        <div
-                          className="w-14 h-14 rounded-xl flex items-center justify-center mb-3"
-                          style={{ background: nextMeta.color + '22' }}
-                        >
-                          <NextIcon size={28} color={nextMeta.color} />
-                        </div>
-                        <h3 className="text-lg font-bold text-white text-center opacity-60">
-                          {next.habit.name}
-                        </h3>
-                      </div>
-                    );
-                  })()}
-                </motion.div>
-              )}
-
-              {/* Active card */}
-              {cards[currentIndex] && (
-                <SwipeCard
-                  key={cards[currentIndex].habit.id}
-                  card={cards[currentIndex]}
-                  x={frontX}
-                  onSwipeRight={handleSwipeRight}
-                  onSwipeLeft={handleSwipeLeft}
-                  onExitStart={() => setIsAnimating(true)}
-                  disabled={isAnimating}
-                />
-              )}
-            </div>
-
-            {/* Action buttons */}
-            <div className="flex gap-3 mt-3 shrink-0">
-              <button
-                onClick={handleTapSkip}
-                disabled={isAnimating}
-                className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl border border-gray-600 text-gray-400 font-medium active:bg-gray-800 transition-colors disabled:opacity-40"
-              >
-                <ChevronLeft size={18} />
-                <span>Skip</span>
-              </button>
-              <button
-                onClick={handleTapDone}
-                disabled={isAnimating}
-                className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl bg-emerald-600 text-white font-medium active:bg-emerald-700 transition-colors disabled:opacity-40"
-              >
-                <span>Done</span>
-                <Check size={18} />
-              </button>
-            </div>
-
-            {/* Spacer for layout balance */}
-            <div className="shrink-0 h-4" />
-          </div>
-        )}
-
-        {/* Don't show today checkbox */}
-        {selectedDate === todayStr && (
-          <div className="px-4 pb-4 pt-1 shrink-0">
-            <label className="flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={dontShowCheckInToday === todayStr}
-                onChange={handleDontShowToggle}
-                className="w-3.5 h-3.5 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-0 focus:ring-offset-0"
-              />
-              Don&apos;t auto-open today
-            </label>
-          </div>
+          <WeeklyView
+            weekDates={weekDates}
+            todayStr={todayStr}
+            onSelectDay={handleSelectDay}
+          />
         )}
       </div>
 
-      {/* Celebration burst */}
-      <AnimatePresence>
-        {showCelebration && (
-          <CelebrationBurst onDone={() => setShowCelebration(false)} />
-        )}
-      </AnimatePresence>
-
-      {/* Fly-to-HUD reward animation */}
-      <AnimatePresence mode="wait">
-        {rewardFloatData && (
-          <RewardFloat
-            key={rewardFloatKey}
-            xp={rewardFloatData.xp}
-            coins={rewardFloatData.coins}
-            isSurpriseBonus={rewardFloatData.isSurpriseBonus}
-            onDone={() => setRewardFloatData(null)}
-          />
-        )}
-      </AnimatePresence>
-
-      {/* HabitList overlay */}
+      {/* HabitList overlay (from settings gear) */}
       {showHabitList && <HabitList onClose={() => setShowHabitList(false)} />}
     </>
   );

--- a/src/components/DailyView.tsx
+++ b/src/components/DailyView.tsx
@@ -1,0 +1,813 @@
+'use client';
+
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
+import { Flame, ChevronLeft, Check, Trophy, Sparkles } from 'lucide-react';
+import { motion, useMotionValue, useTransform, animate, AnimatePresence, type PanInfo, type MotionValue } from 'framer-motion';
+import { useGameStore } from '@/stores/game-store';
+import { useHabitStore } from '@/stores/habit-store';
+import { usePlayerStore } from '@/stores/player-store';
+import { CATEGORY_META } from '@/config/habit-categories';
+import { isScheduledForDate, formatDateString } from '@/lib/schedule-utils';
+import { calculateCheckInReward, rollSurpriseBonus } from '@/lib/economy-engine';
+import { checkStreakMilestone } from '@/lib/streak-engine';
+import { detectLevelUps } from '@/lib/leveling-engine';
+import { calculateStreak } from '@/lib/streak-utils';
+import { GAME_CONFIG } from '@/config/game-config';
+import { ASSET_CATALOG } from '@/config/asset-catalog';
+import { db } from '@/db/db';
+import type { Habit } from '@/types/habit';
+import type { CheckIn } from '@/types/check-in';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface CardItem {
+  habit: Habit;
+  streak: number;
+  monthProgress: { done: number; total: number };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TIME_PRIORITY: Record<string, number> = {
+  morning: 0,
+  afternoon: 1,
+  evening: 2,
+  anytime: 3,
+};
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getMonthProgress(
+  habit: Habit,
+  selectedDate: string,
+  allCheckIns: CheckIn[],
+): { done: number; total: number } {
+  const [year, month] = selectedDate.split('-').map(Number);
+  const today = formatDateString(new Date());
+  const lastDay = selectedDate <= today ? selectedDate : today;
+
+  const completedSet = new Set(
+    allCheckIns.filter((c) => c.habitId === habit.id && c.completed).map((c) => c.date),
+  );
+
+  let total = 0;
+  let done = 0;
+  const d = new Date(year, month - 1, 1);
+  while (d.getMonth() === month - 1) {
+    const ds = formatDateString(d);
+    if (ds > lastDay) break;
+    if (isScheduledForDate(habit, ds)) {
+      total++;
+      if (completedSet.has(ds)) done++;
+    }
+    d.setDate(d.getDate() + 1);
+  }
+  return { done, total };
+}
+
+// ---------------------------------------------------------------------------
+// Celebration particles
+// ---------------------------------------------------------------------------
+
+function CelebrationBurst({ onDone }: { onDone: () => void }) {
+  const particles = useMemo(() => {
+    const colors = ['#10B981', '#F59E0B', '#8B5CF6', '#EC4899', '#3B82F6', '#EF4444'];
+    return Array.from({ length: 20 }, (_, i) => ({
+      id: i,
+      x: (Math.random() - 0.5) * 300,
+      y: -(Math.random() * 250 + 80),
+      rotate: Math.random() * 720 - 360,
+      scale: Math.random() * 0.6 + 0.4,
+      color: colors[Math.floor(Math.random() * colors.length)],
+    }));
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(onDone, 800);
+    return () => clearTimeout(t);
+  }, [onDone]);
+
+  return (
+    <div className="fixed inset-0 pointer-events-none" style={{ zIndex: 260 }}>
+      <div className="absolute left-1/2 top-1/2">
+        {particles.map((p) => (
+          <motion.div
+            key={p.id}
+            initial={{ x: 0, y: 0, scale: 1, opacity: 1 }}
+            animate={{
+              x: p.x,
+              y: p.y,
+              scale: p.scale,
+              opacity: 0,
+              rotate: p.rotate,
+            }}
+            transition={{ duration: 0.7, ease: 'easeOut' }}
+            className="absolute w-2.5 h-2.5 rounded-full"
+            style={{ backgroundColor: p.color }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fly-to-HUD reward animation
+// ---------------------------------------------------------------------------
+
+function RewardFloat({
+  xp,
+  coins,
+  isSurpriseBonus,
+  onDone,
+}: {
+  xp: number;
+  coins: number;
+  isSurpriseBonus: boolean;
+  onDone?: () => void;
+}) {
+  const [phase, setPhase] = useState<'appear' | 'pulse' | 'fly'>('appear');
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setPhase('pulse'), 200);
+    const t2 = setTimeout(() => setPhase('fly'), 1200);
+    const t3 = setTimeout(() => onDone?.(), 1800);
+    return () => { clearTimeout(t1); clearTimeout(t2); clearTimeout(t3); };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <motion.div
+      className="fixed left-0 right-0 flex justify-center pointer-events-none"
+      style={{ top: '35%', zIndex: 270 }}
+      initial={{ opacity: 0, scale: 0.3, y: 20 }}
+      animate={
+        phase === 'fly'
+          ? { opacity: 0, scale: 0.2, y: -350, x: -100 }
+          : { opacity: 1, scale: 1, y: 0, x: 0 }
+      }
+      transition={
+        phase === 'fly'
+          ? { duration: 0.6, ease: [0.4, 0, 0.2, 1] }
+          : { type: 'spring', stiffness: 300, damping: 15, mass: 0.8 }
+      }
+    >
+      <div className="flex flex-col items-center gap-2">
+        {isSurpriseBonus && (
+          <motion.span
+            className="text-amber-300 font-black text-base tracking-widest uppercase"
+            style={{ textShadow: '0 0 20px rgba(251, 191, 36, 0.6), 0 0 40px rgba(251, 191, 36, 0.3)' }}
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.15, duration: 0.3 }}
+          >
+            Surprise Bonus!
+          </motion.span>
+        )}
+        <motion.div
+          className="flex items-center gap-4 px-6 py-3 rounded-2xl"
+          style={{
+            background: 'radial-gradient(ellipse at center, rgba(16,185,129,0.15) 0%, transparent 70%)',
+          }}
+          animate={
+            phase === 'pulse'
+              ? { scale: [1, 1.08, 1], transition: { duration: 0.5, ease: 'easeInOut' } }
+              : {}
+          }
+        >
+          <div className="flex items-center gap-1.5">
+            <Sparkles size={22} className="text-emerald-400" />
+            <span
+              className="text-emerald-300 font-extrabold text-2xl"
+              style={{ textShadow: '0 0 16px rgba(16,185,129,0.5), 0 2px 4px rgba(0,0,0,0.3)' }}
+            >
+              +{xp} XP
+            </span>
+          </div>
+          <span
+            className="text-yellow-300 font-extrabold text-2xl"
+            style={{ textShadow: '0 0 16px rgba(252,211,77,0.5), 0 2px 4px rgba(0,0,0,0.3)', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+          >
+            +{coins} <img src="/assets/coin/coin.svg" alt="coin" style={{ width: 28, height: 28 }} />
+          </span>
+        </motion.div>
+      </div>
+    </motion.div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function DateStrip({
+  weekDates,
+  selectedDate,
+  todayStr,
+  onSelect,
+}: {
+  weekDates: string[];
+  selectedDate: string;
+  todayStr: string;
+  onSelect: (date: string) => void;
+}) {
+  return (
+    <div className="flex gap-1.5 px-4 py-2">
+      {weekDates.map((date, i) => {
+        const isToday = date === todayStr;
+        const isFuture = date > todayStr;
+        const isSelected = date === selectedDate;
+        const dayNum = date.split('-')[2];
+
+        return (
+          <button
+            key={date}
+            onClick={() => onSelect(date)}
+            disabled={isFuture}
+            className={`flex-1 flex flex-col items-center py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              isSelected
+                ? 'bg-violet-600 text-white'
+                : isToday
+                  ? 'bg-violet-600/20 text-violet-300'
+                  : isFuture
+                    ? 'opacity-30 pointer-events-none text-gray-500'
+                    : 'text-gray-400 active:bg-gray-700'
+            }`}
+          >
+            <span className="text-[10px]">{DAY_LABELS[i]}</span>
+            <span className="text-sm">{parseInt(dayNum)}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SwipeCard({
+  card,
+  x,
+  onSwipeRight,
+  onSwipeLeft,
+  onExitStart,
+  disabled,
+}: {
+  card: CardItem;
+  x: MotionValue<number>;
+  onSwipeRight: () => void;
+  onSwipeLeft: () => void;
+  onExitStart?: () => void;
+  disabled?: boolean;
+}) {
+  const [exiting, setExiting] = useState(false);
+  const rotate = useTransform(x, [-200, 0, 200], [-12, 0, 12]);
+  const doneOpacity = useTransform(x, [0, 60], [0, 1]);
+  const skipOpacity = useTransform(x, [-60, 0], [1, 0]);
+
+  const meta = CATEGORY_META[card.habit.category];
+  const Icon = meta.icon;
+
+  function handleDragEnd(_: unknown, info: PanInfo) {
+    if (exiting || disabled) return;
+
+    const { offset, velocity } = info;
+    const absX = Math.abs(offset.x);
+    const absVel = Math.abs(velocity.x);
+
+    const triggered =
+      absX > 50 || absVel > 250 || (absX > 25 && absVel > 100);
+
+    if (!triggered) {
+      animate(x, 0, { type: 'spring', stiffness: 600, damping: 30 });
+      return;
+    }
+
+    setExiting(true);
+    onExitStart?.();
+
+    const direction = offset.x > 0 ? 1 : -1;
+    const duration = Math.max(0.1, Math.min(0.25, 150 / Math.max(absVel, 200)));
+
+    animate(x, direction * (window.innerWidth + 200), {
+      type: 'tween',
+      duration,
+      ease: 'easeOut',
+    }).then(() => {
+      if (direction === 1) onSwipeRight();
+      else onSwipeLeft();
+    });
+  }
+
+  return (
+    <motion.div
+      style={{ x, rotate, willChange: 'transform' }}
+      drag={!exiting && !disabled ? 'x' : false}
+      dragMomentum={false}
+      onDragEnd={handleDragEnd}
+      className="absolute inset-0 touch-none"
+    >
+      <div className="h-full rounded-2xl bg-gray-800 border border-gray-700 px-6 py-8 flex flex-col items-center justify-center relative overflow-hidden select-none">
+        {/* Swipe indicators */}
+        <motion.div
+          style={{ opacity: doneOpacity }}
+          className="absolute top-4 left-4 px-3 py-1 rounded-full bg-emerald-500/20 border-2 border-emerald-500 text-emerald-400 text-sm font-bold"
+        >
+          DONE
+        </motion.div>
+        <motion.div
+          style={{ opacity: skipOpacity }}
+          className="absolute top-4 right-4 px-3 py-1 rounded-full bg-gray-500/20 border-2 border-gray-500 text-gray-400 text-sm font-bold"
+        >
+          SKIP
+        </motion.div>
+
+        {/* Category icon */}
+        <div
+          className="w-16 h-16 rounded-2xl flex items-center justify-center mb-4"
+          style={{ background: meta.color + '22' }}
+        >
+          <Icon size={32} color={meta.color} />
+        </div>
+
+        {/* Difficulty badge */}
+        <span
+          className="text-xs font-semibold px-2.5 py-1 rounded-full mb-3"
+          style={{ background: meta.color + '22', color: meta.color }}
+        >
+          {card.habit.difficulty.charAt(0).toUpperCase() + card.habit.difficulty.slice(1)}
+        </span>
+
+        {/* Habit name */}
+        <h3 className="text-xl font-bold text-white text-center mb-4">{card.habit.name}</h3>
+
+        {/* Monthly progress */}
+        <p className="text-sm text-gray-400 mb-2">
+          {card.monthProgress.done}/{card.monthProgress.total} this month
+        </p>
+
+        {/* Streak */}
+        {card.streak > 0 && (
+          <div className="flex items-center gap-1 text-orange-400">
+            <Flame size={16} />
+            <span className="text-sm font-semibold">{card.streak} day streak</span>
+          </div>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+function SessionSummary({
+  completed,
+  total,
+  xp,
+  coins,
+  perfectDay,
+  onReturn,
+}: {
+  completed: number;
+  total: number;
+  xp: number;
+  coins: number;
+  perfectDay: boolean;
+  onReturn: () => void;
+}) {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+      {perfectDay && (
+        <div className="flex items-center gap-2 mb-4 text-yellow-400">
+          <Trophy size={24} />
+          <span className="text-lg font-bold">Perfect check-in!</span>
+          <Trophy size={24} />
+        </div>
+      )}
+
+      <h2 className="text-2xl font-bold text-white mb-6">Session Complete</h2>
+
+      <div className="space-y-3 mb-8 w-full max-w-[240px]">
+        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
+          <span className="text-gray-400 text-sm">Habits completed</span>
+          <span className="text-white font-bold">{completed}/{total}</span>
+        </div>
+        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
+          <span className="text-gray-400 text-sm">XP earned</span>
+          <span className="text-emerald-400 font-bold">+{xp}</span>
+        </div>
+        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
+          <span className="text-gray-400 text-sm">Coins earned</span>
+          <span className="text-yellow-400 font-bold">+{coins}</span>
+        </div>
+      </div>
+
+      <button
+        onClick={onReturn}
+        className="px-8 py-3 rounded-xl bg-violet-600 text-white font-semibold active:bg-violet-700 transition-colors"
+      >
+        Return to City
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main Component
+// ---------------------------------------------------------------------------
+
+interface DailyViewProps {
+  weekDates: string[];
+  todayStr: string;
+  selectedDate: string;
+  onSelectDate: (date: string) => void;
+  onClose: () => void;
+}
+
+export default function DailyView({ weekDates, todayStr, selectedDate, onSelectDate, onClose }: DailyViewProps) {
+  const firstWeekBoostActive = useGameStore((s) => s.firstWeekBoostActive);
+  const doubleXPEventActive = useGameStore((s) => s.doubleXPEventActive);
+  const queueReward = useGameStore((s) => s.queueReward);
+
+  const habits = useHabitStore((s) => s.habits);
+  const habitCheckIn = useHabitStore((s) => s.checkIn);
+  const getScheduledForDate = useHabitStore((s) => s.getScheduledForDate);
+
+  const addXP = usePlayerStore((s) => s.addXP);
+  const addCoins = usePlayerStore((s) => s.addCoins);
+  const dontShowCheckInToday = usePlayerStore((s) => s.dontShowCheckInToday);
+  const setDontShowCheckInToday = usePlayerStore((s) => s.setDontShowCheckInToday);
+
+  const [cards, setCards] = useState<CardItem[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [sessionXP, setSessionXP] = useState(0);
+  const [sessionCoins, setSessionCoins] = useState(0);
+  const [sessionCompleted, setSessionCompleted] = useState(0);
+  const [sessionTotal, setSessionTotal] = useState(0);
+  const [showSummary, setShowSummary] = useState(false);
+  const [sessionCompletedIds, setSessionCompletedIds] = useState<Set<string>>(new Set());
+  const [initialCompletedIds, setInitialCompletedIds] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [perfectDay, setPerfectDay] = useState(false);
+  const [showCelebration, setShowCelebration] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [rewardFloatKey, setRewardFloatKey] = useState(0);
+  const [rewardFloatData, setRewardFloatData] = useState<{ xp: number; coins: number; isSurpriseBonus: boolean } | null>(null);
+  const sessionStartXPRef = useRef(usePlayerStore.getState().xp);
+
+  // Shared motion value for the front card
+  const frontX = useMotionValue(0);
+  const backScale = useTransform(frontX, (v) => 0.95 + Math.min(Math.abs(v) / 150, 1) * 0.05);
+  const backOpacity = useTransform(frontX, (v) => 0.6 + Math.min(Math.abs(v) / 150, 1) * 0.4);
+
+  // Reset shared motion value when the active card changes
+  useLayoutEffect(() => {
+    frontX.set(0);
+    setIsAnimating(false);
+  }, [currentIndex, frontX]);
+
+  // Load cards when date or habits change
+  const loadCards = useCallback(
+    async (date: string) => {
+      setLoading(true);
+      const scheduled = getScheduledForDate(date);
+      const checkIns = await db.checkIns.where('date').equals(date).toArray();
+      const allCheckIns = await db.checkIns.toArray();
+
+      const completedIds = new Set(
+        checkIns.filter((c) => c.completed).map((c) => c.habitId),
+      );
+
+      setInitialCompletedIds(completedIds);
+
+      const pending = scheduled.filter((h) => !completedIds.has(h.id));
+
+      const byHabit: Record<string, CheckIn[]> = {};
+      for (const ci of allCheckIns) {
+        (byHabit[ci.habitId] ??= []).push(ci);
+      }
+
+      const cardItems: CardItem[] = pending
+        .map((habit) => ({
+          habit,
+          streak: calculateStreak(habit, byHabit[habit.id] ?? []),
+          monthProgress: getMonthProgress(habit, date, allCheckIns),
+        }))
+        .sort((a, b) => {
+          const timeDiff =
+            (TIME_PRIORITY[a.habit.timeOfDay] ?? 3) - (TIME_PRIORITY[b.habit.timeOfDay] ?? 3);
+          if (timeDiff !== 0) return timeDiff;
+          return a.habit.sortOrder - b.habit.sortOrder;
+        });
+
+      setCards(cardItems);
+      setCurrentIndex(0);
+      setSessionXP(0);
+      setSessionCoins(0);
+      setSessionCompleted(0);
+      setSessionTotal(scheduled.length);
+      setSessionCompletedIds(new Set());
+      setPerfectDay(false);
+      setIsAnimating(false);
+      frontX.set(0);
+
+      if (cardItems.length === 0) {
+        const alreadyCompleted = completedIds.size;
+        setSessionCompleted(alreadyCompleted);
+        setShowSummary(true);
+      } else {
+        setShowSummary(false);
+      }
+
+      setLoading(false);
+    },
+    [getScheduledForDate], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  useEffect(() => {
+    loadCards(selectedDate);
+  }, [selectedDate, habits, loadCards]);
+
+  const finishSession = useCallback(
+    (completedIds: Set<string>) => {
+      const allCompletedIds = new Set([...initialCompletedIds, ...completedIds]);
+      const scheduled = getScheduledForDate(selectedDate);
+      const isPerfect =
+        scheduled.length > 0 && scheduled.every((h) => allCompletedIds.has(h.id));
+
+      if (isPerfect) {
+        const perfectXP = GAME_CONFIG.bonuses.daily_perfect.xp;
+        const perfectCoins = GAME_CONFIG.bonuses.daily_perfect.coins;
+        addXP(perfectXP);
+        addCoins(perfectCoins);
+        setSessionXP((s) => s + perfectXP);
+        setSessionCoins((s) => s + perfectCoins);
+        setPerfectDay(true);
+        queueReward({
+          type: 'daily-perfect',
+          payload: { xp: perfectXP, coins: perfectCoins },
+        });
+      }
+
+      // Detect deferred level-ups across the entire session
+      const currentXP = usePlayerStore.getState().xp;
+      const levelResult = detectLevelUps(sessionStartXPRef.current, currentXP, ASSET_CATALOG);
+      if (levelResult.levelsGained.length > 0) {
+        queueReward({
+          type: 'level-up',
+          payload: { level: levelResult.newLevel, unlockedAssets: levelResult.unlockedAssets },
+        });
+      }
+
+      // Re-capture start XP for the next date session
+      sessionStartXPRef.current = usePlayerStore.getState().xp;
+      setShowSummary(true);
+    },
+    [initialCompletedIds, getScheduledForDate, selectedDate, addXP, addCoins, queueReward],
+  );
+
+  const handleSwipeRight = useCallback(() => {
+    const card = cards[currentIndex];
+    if (!card) return;
+
+    const surprise = rollSurpriseBonus();
+    const reward = calculateCheckInReward(card.habit.difficulty, {
+      surpriseBonus: surprise,
+      firstWeekActive: firstWeekBoostActive,
+      doubleXPActive: doubleXPEventActive,
+    });
+
+    habitCheckIn(card.habit.id, selectedDate, reward.xp, reward.coins);
+    addXP(reward.xp);
+    addCoins(reward.coins);
+
+    setRewardFloatData({ xp: reward.xp, coins: reward.coins, isSurpriseBonus: surprise });
+    setRewardFloatKey((k) => k + 1);
+
+    const newStreak = card.streak + 1;
+    const milestone = checkStreakMilestone(newStreak);
+    if (milestone !== null) {
+      queueReward({
+        type: 'streak-milestone',
+        payload: { streak: newStreak, habitName: card.habit.name },
+      });
+    }
+
+    const newCompletedIds = new Set(sessionCompletedIds);
+    newCompletedIds.add(card.habit.id);
+
+    setSessionXP((s) => s + reward.xp);
+    setSessionCoins((s) => s + reward.coins);
+    setSessionCompleted((s) => s + 1);
+    setSessionCompletedIds(newCompletedIds);
+
+    setShowCelebration(true);
+
+    const nextIndex = currentIndex + 1;
+    if (nextIndex >= cards.length) {
+      finishSession(newCompletedIds);
+    } else {
+      setCurrentIndex(nextIndex);
+    }
+  }, [
+    cards,
+    currentIndex,
+    selectedDate,
+    firstWeekBoostActive,
+    doubleXPEventActive,
+    habitCheckIn,
+    addXP,
+    addCoins,
+    queueReward,
+    sessionCompletedIds,
+    finishSession,
+  ]);
+
+  const handleSwipeLeft = useCallback(() => {
+    const nextIndex = currentIndex + 1;
+    if (nextIndex >= cards.length) {
+      finishSession(sessionCompletedIds);
+    } else {
+      setCurrentIndex(nextIndex);
+    }
+  }, [currentIndex, cards.length, sessionCompletedIds, finishSession]);
+
+  const handleTapDone = useCallback(() => {
+    if (isAnimating) return;
+    setIsAnimating(true);
+    animate(frontX, window.innerWidth + 200, {
+      type: 'tween',
+      duration: 0.25,
+      ease: 'easeOut',
+    }).then(handleSwipeRight);
+  }, [isAnimating, frontX, handleSwipeRight]);
+
+  const handleTapSkip = useCallback(() => {
+    if (isAnimating) return;
+    setIsAnimating(true);
+    animate(frontX, -(window.innerWidth + 200), {
+      type: 'tween',
+      duration: 0.25,
+      ease: 'easeOut',
+    }).then(handleSwipeLeft);
+  }, [isAnimating, frontX, handleSwipeLeft]);
+
+  const handleDontShowToggle = useCallback(() => {
+    if (dontShowCheckInToday === todayStr) {
+      setDontShowCheckInToday(null);
+    } else {
+      setDontShowCheckInToday(todayStr);
+    }
+  }, [dontShowCheckInToday, todayStr, setDontShowCheckInToday]);
+
+  return (
+    <>
+      {/* Date strip */}
+      <DateStrip
+        weekDates={weekDates}
+        selectedDate={selectedDate}
+        todayStr={todayStr}
+        onSelect={onSelectDate}
+      />
+
+      {/* Event banners */}
+      {doubleXPEventActive && (
+        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-amber-500/20 border border-amber-500/40 text-center">
+          <span className="text-amber-400 font-bold text-sm">&#x26A1; 2x XP Active!</span>
+        </div>
+      )}
+      {firstWeekBoostActive && (
+        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-violet-500/20 border border-violet-500/40 text-center">
+          <span className="text-violet-300 font-bold text-sm">&#x1F680; 2x XP BOOST — First Week!</span>
+        </div>
+      )}
+
+      {/* Card area */}
+      {loading ? (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-gray-500 text-sm">Loading...</div>
+        </div>
+      ) : showSummary ? (
+        <SessionSummary
+          completed={sessionCompleted}
+          total={sessionTotal}
+          xp={sessionXP}
+          coins={sessionCoins}
+          perfectDay={perfectDay}
+          onReturn={onClose}
+        />
+      ) : (
+        <div className="flex-1 flex flex-col px-4 pt-2 pb-2 min-h-0">
+          {/* Counter */}
+          <p className="text-xs text-gray-500 mb-2 text-center shrink-0">
+            {currentIndex + 1} / {cards.length}
+          </p>
+
+          {/* Card stack */}
+          <div className="relative flex-1 min-h-0 touch-none">
+            {/* Next card (behind) */}
+            {currentIndex + 1 < cards.length && (
+              <motion.div
+                className="absolute inset-0 rounded-2xl bg-gray-800 border border-gray-700 pointer-events-none overflow-hidden"
+                style={{ scale: backScale, opacity: backOpacity }}
+              >
+                {(() => {
+                  const next = cards[currentIndex + 1];
+                  const nextMeta = CATEGORY_META[next.habit.category];
+                  const NextIcon = nextMeta.icon;
+                  return (
+                    <div className="h-full flex flex-col items-center justify-center px-6 select-none">
+                      <div
+                        className="w-14 h-14 rounded-xl flex items-center justify-center mb-3"
+                        style={{ background: nextMeta.color + '22' }}
+                      >
+                        <NextIcon size={28} color={nextMeta.color} />
+                      </div>
+                      <h3 className="text-lg font-bold text-white text-center opacity-60">
+                        {next.habit.name}
+                      </h3>
+                    </div>
+                  );
+                })()}
+              </motion.div>
+            )}
+
+            {/* Active card */}
+            {cards[currentIndex] && (
+              <SwipeCard
+                key={cards[currentIndex].habit.id}
+                card={cards[currentIndex]}
+                x={frontX}
+                onSwipeRight={handleSwipeRight}
+                onSwipeLeft={handleSwipeLeft}
+                onExitStart={() => setIsAnimating(true)}
+                disabled={isAnimating}
+              />
+            )}
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex gap-3 mt-3 shrink-0">
+            <button
+              onClick={handleTapSkip}
+              disabled={isAnimating}
+              className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl border border-gray-600 text-gray-400 font-medium active:bg-gray-800 transition-colors disabled:opacity-40"
+            >
+              <ChevronLeft size={18} />
+              <span>Skip</span>
+            </button>
+            <button
+              onClick={handleTapDone}
+              disabled={isAnimating}
+              className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl bg-emerald-600 text-white font-medium active:bg-emerald-700 transition-colors disabled:opacity-40"
+            >
+              <span>Done</span>
+              <Check size={18} />
+            </button>
+          </div>
+
+          {/* Spacer */}
+          <div className="shrink-0 h-4" />
+        </div>
+      )}
+
+      {/* Don't show today checkbox */}
+      {selectedDate === todayStr && (
+        <div className="px-4 pb-4 pt-1 shrink-0">
+          <label className="flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={dontShowCheckInToday === todayStr}
+              onChange={handleDontShowToggle}
+              className="w-3.5 h-3.5 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-0 focus:ring-offset-0"
+            />
+            Don&apos;t auto-open today
+          </label>
+        </div>
+      )}
+
+      {/* Celebration burst */}
+      <AnimatePresence>
+        {showCelebration && (
+          <CelebrationBurst onDone={() => setShowCelebration(false)} />
+        )}
+      </AnimatePresence>
+
+      {/* Fly-to-HUD reward animation */}
+      <AnimatePresence mode="wait">
+        {rewardFloatData && (
+          <RewardFloat
+            key={rewardFloatKey}
+            xp={rewardFloatData.xp}
+            coins={rewardFloatData.coins}
+            isSurpriseBonus={rewardFloatData.isSurpriseBonus}
+            onDone={() => setRewardFloatData(null)}
+          />
+        )}
+      </AnimatePresence>
+    </>
+  );
+}

--- a/src/components/WeeklyView.tsx
+++ b/src/components/WeeklyView.tsx
@@ -1,0 +1,302 @@
+'use client';
+
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Check, Circle, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useHabitStore } from '@/stores/habit-store';
+import { isScheduledForDate, formatDateString } from '@/lib/schedule-utils';
+import { getWeeklyBonusMultiplier } from '@/lib/weekly-engine';
+import type { Habit } from '@/types/habit';
+import type { CheckIn } from '@/types/check-in';
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function getWeekDatesFromMonday(mondayStr: string): string[] {
+  const monday = new Date(mondayStr + 'T00:00:00');
+  const dates: string[] = [];
+  for (let i = 0; i < 7; i++) {
+    const day = new Date(monday);
+    day.setDate(monday.getDate() + i);
+    dates.push(formatDateString(day));
+  }
+  return dates;
+}
+
+function shiftWeek(mondayStr: string, offset: number): string {
+  const d = new Date(mondayStr + 'T00:00:00');
+  d.setDate(d.getDate() + offset * 7);
+  return formatDateString(d);
+}
+
+function formatWeekRange(dates: string[]): string {
+  const start = new Date(dates[0] + 'T00:00:00');
+  const end = new Date(dates[6] + 'T00:00:00');
+  const sMonth = MONTH_NAMES[start.getMonth()];
+  const eMonth = MONTH_NAMES[end.getMonth()];
+  if (sMonth === eMonth) {
+    return `${sMonth} ${start.getDate()}–${end.getDate()}`;
+  }
+  return `${sMonth} ${start.getDate()} – ${eMonth} ${end.getDate()}`;
+}
+
+interface WeeklyViewProps {
+  weekDates: string[];
+  todayStr: string;
+  onSelectDay: (date: string) => void;
+}
+
+export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyViewProps) {
+  const habits = useHabitStore((s) => s.habits);
+  const getCheckInsForWeek = useHabitStore((s) => s.getCheckInsForWeek);
+
+  const currentMonday = weekDates[0];
+  const [viewingMonday, setViewingMonday] = useState(currentMonday);
+  const isPastWeek = viewingMonday < currentMonday;
+  const displayDates = useMemo(
+    () => (isPastWeek ? getWeekDatesFromMonday(viewingMonday) : weekDates),
+    [viewingMonday, isPastWeek, weekDates],
+  );
+
+  const [checkIns, setCheckIns] = useState<CheckIn[]>([]);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Fetch check-ins for the displayed week
+  useEffect(() => {
+    async function load() {
+      const data = await getCheckInsForWeek(displayDates[0]);
+      setCheckIns(data);
+    }
+    load();
+  }, [displayDates, getCheckInsForWeek, habits]);
+
+  // Completion lookup: "YYYY-MM-DD:habitId"
+  const completedSet = useMemo(() => {
+    const set = new Set<string>();
+    for (const ci of checkIns) {
+      if (ci.completed) {
+        set.add(`${ci.date}:${ci.habitId}`);
+      }
+    }
+    return set;
+  }, [checkIns]);
+
+  // Scheduled habits per day
+  const scheduledByDay = useMemo(() => {
+    const map = new Map<string, Habit[]>();
+    for (const date of displayDates) {
+      map.set(date, habits.filter((h) => isScheduledForDate(h, date)));
+    }
+    return map;
+  }, [displayDates, habits]);
+
+  // The effective "last countable day" for stats — for past weeks, count all 7 days
+  const lastCountableDay = isPastWeek ? displayDates[6] : todayStr;
+
+  // Weekly stats for footer
+  const weeklyStats = useMemo(() => {
+    let totalScheduled = 0;
+    let totalCompleted = 0;
+
+    for (const date of displayDates) {
+      if (date > lastCountableDay) continue;
+      const dayHabits = scheduledByDay.get(date) ?? [];
+      totalScheduled += dayHabits.length;
+      for (const h of dayHabits) {
+        if (completedSet.has(`${date}:${h.id}`)) {
+          totalCompleted++;
+        }
+      }
+    }
+
+    const percentage = totalScheduled > 0 ? Math.round((totalCompleted / totalScheduled) * 100) : 0;
+    const multiplier = getWeeklyBonusMultiplier(percentage);
+
+    return { totalScheduled, totalCompleted, percentage, multiplier };
+  }, [displayDates, lastCountableDay, scheduledByDay, completedSet]);
+
+  // Auto-scroll today's column into center view (current week only)
+  useEffect(() => {
+    if (isPastWeek || !scrollRef.current) return;
+    const todayIndex = displayDates.indexOf(todayStr);
+    if (todayIndex === -1) return;
+
+    const container = scrollRef.current;
+    const columns = container.querySelectorAll('[data-day-col]');
+    if (columns[todayIndex]) {
+      const col = columns[todayIndex] as HTMLElement;
+      const scrollLeft = col.offsetLeft - container.offsetWidth / 2 + col.offsetWidth / 2;
+      container.scrollTo({ left: Math.max(0, scrollLeft), behavior: 'smooth' });
+    }
+  }, [displayDates, todayStr, isPastWeek]);
+
+  const goToPreviousWeek = useCallback(() => {
+    setViewingMonday((m) => shiftWeek(m, -1));
+  }, []);
+
+  const goToCurrentWeek = useCallback(() => {
+    setViewingMonday(currentMonday);
+  }, [currentMonday]);
+
+  // Column color coding
+  function getColumnClasses(date: string): string {
+    if (!isPastWeek && date > todayStr) return 'opacity-40';
+
+    const dayHabits = scheduledByDay.get(date) ?? [];
+    if (dayHabits.length === 0) return '';
+
+    const completedCount = dayHabits.filter((h) => completedSet.has(`${date}:${h.id}`)).length;
+    if (completedCount === dayHabits.length) return 'bg-emerald-500/10';
+    if (completedCount > 0) return 'bg-amber-500/10';
+    return '';
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      {/* Week header with navigation */}
+      <div className="flex items-center justify-between px-4 py-2">
+        <button
+          onClick={goToPreviousWeek}
+          className="flex items-center gap-1 text-sm text-gray-400 active:text-white transition-colors"
+        >
+          <ChevronLeft size={16} />
+          <span>Prev</span>
+        </button>
+        <span className="text-sm font-medium text-gray-300">
+          {formatWeekRange(displayDates)}
+        </span>
+        {isPastWeek ? (
+          <button
+            onClick={goToCurrentWeek}
+            className="flex items-center gap-1 text-sm text-violet-400 active:text-violet-300 transition-colors"
+          >
+            <span>Current</span>
+            <ChevronRight size={16} />
+          </button>
+        ) : (
+          <div className="w-16" />
+        )}
+      </div>
+
+      {/* Past week indicator */}
+      {isPastWeek && (
+        <div className="mx-4 mb-2 py-1.5 px-3 rounded-lg bg-gray-800/60 text-center">
+          <span className="text-xs text-gray-500">Past week — read only</span>
+        </div>
+      )}
+
+      {/* Scrollable 7-column grid */}
+      <div
+        ref={scrollRef}
+        className="flex-1 overflow-x-auto overflow-y-auto px-2 pb-2"
+      >
+        <div className="flex gap-1.5 min-h-full" style={{ minWidth: 'min(100%, 980px)' }}>
+          {displayDates.map((date, i) => {
+            const isFuture = !isPastWeek && date > todayStr;
+            const isToday = date === todayStr;
+            const dayHabits = scheduledByDay.get(date) ?? [];
+            const dayNum = date.split('-')[2];
+
+            const tappable = !isFuture && !isPastWeek;
+
+            return (
+              <button
+                key={date}
+                data-day-col
+                onClick={() => tappable && onSelectDay(date)}
+                disabled={!tappable}
+                className={`flex flex-col rounded-xl flex-1 min-w-[170px] text-left ${getColumnClasses(date)} ${
+                  isToday ? 'ring-2 ring-violet-500/50' : ''
+                } ${tappable ? 'active:bg-gray-700/30 cursor-pointer' : 'cursor-default'}`}
+              >
+                {/* Day header */}
+                <div
+                  className={`flex flex-col items-center py-2.5 rounded-t-xl ${
+                    isToday ? 'bg-violet-600/20' : ''
+                  }`}
+                >
+                  <span className={`text-xs font-medium ${isToday ? 'text-violet-300' : 'text-gray-400'}`}>
+                    {DAY_LABELS[i]}
+                  </span>
+                  <span className={`text-lg font-bold ${isToday ? 'text-white' : 'text-gray-300'}`}>
+                    {parseInt(dayNum)}
+                  </span>
+                </div>
+
+                {/* Habits list */}
+                <div className="flex-1 px-1.5 pb-2 space-y-1">
+                  {dayHabits.map((habit) => {
+                    const isCompleted = completedSet.has(`${date}:${habit.id}`);
+
+                    return (
+                      <div
+                        key={habit.id}
+                        className="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-lg"
+                      >
+                        {isCompleted ? (
+                          <Check size={14} className="text-emerald-400 shrink-0" />
+                        ) : (
+                          <Circle size={14} className="text-gray-500 shrink-0" />
+                        )}
+                        <span
+                          className={`text-xs truncate ${
+                            isCompleted ? 'text-gray-500 line-through' : 'text-gray-300'
+                          }`}
+                        >
+                          {habit.name}
+                        </span>
+                      </div>
+                    );
+                  })}
+                  {dayHabits.length === 0 && (
+                    <p className="text-[10px] text-gray-600 text-center py-2">No habits</p>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Footer — progress bar + stats */}
+      <div className="shrink-0 px-4 pt-3 pb-4 border-t border-gray-800">
+        {/* Progress bar */}
+        <div className="w-full h-2 rounded-full bg-gray-800 mb-3 overflow-hidden">
+          <div
+            className="h-full rounded-full transition-all duration-500"
+            style={{
+              width: `${weeklyStats.percentage}%`,
+              background: weeklyStats.percentage >= 80
+                ? 'linear-gradient(90deg, #10B981, #34D399)'
+                : weeklyStats.percentage >= 50
+                  ? 'linear-gradient(90deg, #F59E0B, #FBBF24)'
+                  : 'linear-gradient(90deg, #6B7280, #9CA3AF)',
+            }}
+          />
+        </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="text-base font-bold text-white">
+              {weeklyStats.totalCompleted}/{weeklyStats.totalScheduled}
+            </span>
+            <span className="text-sm text-gray-400 ml-1.5">
+              completed ({weeklyStats.percentage}%)
+            </span>
+          </div>
+          <div className={`text-sm font-semibold px-2.5 py-1 rounded-full ${
+            weeklyStats.multiplier >= 2
+              ? 'bg-emerald-500/20 text-emerald-400'
+              : weeklyStats.multiplier >= 1
+                ? 'bg-amber-500/20 text-amber-400'
+                : weeklyStats.multiplier > 0
+                  ? 'bg-gray-700 text-gray-300'
+                  : 'bg-gray-800 text-gray-500'
+          }`}>
+            {weeklyStats.multiplier > 0
+              ? `${weeklyStats.multiplier}x bonus`
+              : 'No bonus yet'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/stores/habit-store.ts
+++ b/src/stores/habit-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { db } from '@/db/db';
-import { isScheduledForDate } from '@/lib/schedule-utils';
+import { isScheduledForDate, formatDateString } from '@/lib/schedule-utils';
 import type { Habit } from '@/types/habit';
 import type { CheckIn } from '@/types/check-in';
 
@@ -142,7 +142,7 @@ export const useHabitStore = create<HabitState>((set, get) => ({
     const start = new Date(weekStart + 'T00:00:00');
     const end = new Date(start);
     end.setDate(end.getDate() + 6);
-    const endStr = end.toISOString().slice(0, 10);
+    const endStr = formatDateString(end);
 
     return db.checkIns
       .where('date')


### PR DESCRIPTION
## Summary
- Add Daily/Weekly tab toggle to the check-in screen (segmented pill control)
- Build WeeklyView component: horizontal scrollable 7-column grid (Mon–Sun) with per-day habit completion status, color-coded columns (green/amber/neutral), progress bar footer with bonus tier
- Extract DailyView from CheckInScreen (891→150 lines) keeping all swipe card logic intact
- Add previous week navigation (read-only, non-interactive)
- Fix timezone bug in `getCheckInsForWeek` (`toISOString` → `formatDateString`)

Closes #72

## Test plan
- [ ] Daily tab works as before (swipe cards, rewards, session summary, perfect day)
- [ ] Tab toggle switches between Daily and Weekly views
- [ ] Weekly grid shows 7 columns with today highlighted and auto-scrolled
- [ ] Completed habits show checkmark, pending show empty circle
- [ ] Column color coding: green (all done), amber (partial), neutral (none), dimmed (future)
- [ ] Tap anywhere on a day column → switches to Daily tab with that day pre-selected
- [ ] Future days dimmed and not tappable
- [ ] Footer shows progress bar + completion % + projected bonus tier
- [ ] Previous week navigation loads past week (read-only)
- [ ] "Current →" button returns to current week

🤖 Generated with [Claude Code](https://claude.com/claude-code)