### PR TITLE
feat: analytics & weekly report (issue #55)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,6 +67,10 @@ const SettingsScreen = dynamic(() => import('@/components/SettingsScreen'), {
   ssr: false,
 });
 
+const WeeklyReport = dynamic(() => import('@/components/WeeklyReport'), {
+  ssr: false,
+});
+
 const RewardReveal = dynamic(() => import('@/components/RewardReveal'), {
   ssr: false,
 });
@@ -102,6 +106,7 @@ export default function Home() {
       <ShopScreen />
       <StatsScreen />
       <SettingsScreen />
+      <WeeklyReport />
       <RewardReveal />
       <CheckInScreen />
       <HabitListFromMenu />

--- a/src/components/AllTimeStats.tsx
+++ b/src/components/AllTimeStats.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Flame, Trophy, Zap, Coins, Building2 } from 'lucide-react';
+import { db } from '@/db/db';
+import { usePlayerStore } from '@/stores/player-store';
+import { useInventoryStore } from '@/stores/inventory-store';
+import { getXPProgressInCurrentLevel } from '@/lib/leveling-engine';
+import { calculateLongestStreak } from '@/lib/streak-engine';
+import { getCatalogAsset } from '@/lib/catalog-helpers';
+import type { Habit } from '@/types/habit';
+import type { CheckIn } from '@/types/check-in';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface AllTimeData {
+  totalCoins: number;
+  spentCoins: number;
+  longestStreaks: { name: string; streak: number }[];
+  totalCompleted: number;
+  cityValue: number;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function AllTimeStats() {
+  const xp = usePlayerStore((s) => s.xp);
+  const coins = usePlayerStore((s) => s.coins);
+  const level = usePlayerStore((s) => s.level);
+  const totalPoints = usePlayerStore((s) => s.totalPoints);
+  const placedAssets = useInventoryStore((s) => s.placedAssets);
+
+  const [data, setData] = useState<AllTimeData | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      // Load player profile for totalCoins/spentCoins
+      const profiles = await db.playerProfile.toArray();
+      const profile = profiles[0];
+
+      // Load all habits (including archived) and all check-ins
+      const allHabits = await db.habits.toArray() as (Habit & { archived: number | boolean })[];
+      const allCheckIns = await db.checkIns.toArray();
+
+      if (cancelled) return;
+
+      // Calculate longest streak per habit
+      const activeHabits = allHabits.filter((h) => !h.archived);
+      const longestStreaks: { name: string; streak: number }[] = [];
+      for (const habit of activeHabits) {
+        const longest = calculateLongestStreak(habit.id, allCheckIns, habit);
+        if (longest > 0) {
+          longestStreaks.push({ name: habit.name, streak: longest });
+        }
+      }
+      longestStreaks.sort((a, b) => b.streak - a.streak);
+
+      // Total completed check-ins
+      const totalCompleted = allCheckIns.filter((c: CheckIn) => c.completed).length;
+
+      // City value
+      let cityValue = 0;
+      for (const placed of placedAssets) {
+        const asset = getCatalogAsset(placed.assetId);
+        if (asset) cityValue += asset.price;
+      }
+
+      setData({
+        totalCoins: profile?.totalCoins ?? 0,
+        spentCoins: profile?.spentCoins ?? 0,
+        longestStreaks,
+        totalCompleted,
+        cityValue,
+      });
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [placedAssets]);
+
+  const progress = getXPProgressInCurrentLevel(xp);
+
+  if (!data) {
+    return (
+      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(255,255,255,0.3)' }}>
+        Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ padding: '0 16px 24px', display: 'flex', flexDirection: 'column', gap: 20 }}>
+      {/* Level + XP bar */}
+      <section
+        style={{
+          background: 'linear-gradient(135deg, rgba(59,52,120,0.4), rgba(42,32,96,0.4))',
+          border: '1px solid rgba(139,92,246,0.2)',
+          borderRadius: 14,
+          padding: '20px 16px',
+          textAlign: 'center',
+        }}
+      >
+        <div
+          style={{
+            width: 56,
+            height: 56,
+            borderRadius: 14,
+            background: 'linear-gradient(135deg, #3b3478, #2a2060)',
+            border: '2px solid rgba(139,92,246,0.4)',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            margin: '0 auto 12px',
+          }}
+        >
+          <span style={{ fontSize: 10, fontWeight: 600, color: 'rgba(255,255,255,0.6)', lineHeight: 1 }}>LVL</span>
+          <span style={{ fontSize: 22, fontWeight: 800, color: 'white', lineHeight: 1.1 }}>{level}</span>
+        </div>
+
+        {/* XP bar */}
+        <div style={{ width: '100%', maxWidth: 280, margin: '0 auto' }}>
+          <div
+            style={{
+              height: 8,
+              borderRadius: 4,
+              background: 'rgba(255,255,255,0.1)',
+              overflow: 'hidden',
+              marginBottom: 6,
+            }}
+          >
+            <div
+              style={{
+                height: '100%',
+                width: `${progress.percentage}%`,
+                borderRadius: 4,
+                background: 'linear-gradient(90deg, #06b6d4, #3b82f6)',
+                transition: 'width 0.5s ease',
+              }}
+            />
+          </div>
+          <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.5)' }}>
+            {progress.current.toLocaleString()} / {progress.required.toLocaleString()} XP to Level {level + 1}
+          </div>
+        </div>
+      </section>
+
+      {/* Total Lifetime Points */}
+      <StatCard
+        icon={<Trophy size={20} color="#f59e0b" />}
+        label="Total Lifetime Points"
+        value={totalPoints.toLocaleString()}
+        color="#f59e0b"
+      />
+
+      {/* Coins */}
+      <section
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr',
+          gap: 8,
+        }}
+      >
+        <MiniCard label="Earned" value={data.totalCoins.toLocaleString()} color="#10B981" />
+        <MiniCard label="Spent" value={data.spentCoins.toLocaleString()} color="#EF4444" />
+        <MiniCard label="Balance" value={coins.toLocaleString()} color="#facc15" />
+      </section>
+
+      {/* Longest streaks */}
+      {data.longestStreaks.length > 0 && (
+        <section>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12 }}>
+            <Flame size={18} color="#f97316" />
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(255,255,255,0.7)', margin: 0 }}>
+              Longest Streaks
+            </h2>
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {data.longestStreaks.map((s) => (
+              <div
+                key={s.name}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  background: 'rgba(255,255,255,0.04)',
+                  borderRadius: 10,
+                  padding: '10px 14px',
+                }}
+              >
+                <span style={{ fontSize: 13, color: 'white' }}>{s.name}</span>
+                <span style={{ fontSize: 14, fontWeight: 700, color: '#f97316' }}>
+                  {s.streak} days
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Total habits completed */}
+      <StatCard
+        icon={<Zap size={20} color="#3b82f6" />}
+        label="Total Habits Completed"
+        value={data.totalCompleted.toLocaleString()}
+        color="#3b82f6"
+      />
+
+      {/* City value */}
+      <StatCard
+        icon={<Building2 size={20} color="#8b5cf6" />}
+        label="City Value"
+        value={`${data.cityValue.toLocaleString()} Coins`}
+        color="#8b5cf6"
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function StatCard({
+  icon,
+  label,
+  value,
+  color,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  color: string;
+}) {
+  return (
+    <div
+      style={{
+        background: 'rgba(255,255,255,0.04)',
+        borderRadius: 14,
+        padding: '14px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+      }}
+    >
+      {icon}
+      <div style={{ flex: 1 }}>
+        <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)', marginBottom: 2 }}>{label}</div>
+        <div style={{ fontSize: 18, fontWeight: 700, color }}>{value}</div>
+      </div>
+    </div>
+  );
+}
+
+function MiniCard({ label, value, color }: { label: string; value: string; color: string }) {
+  return (
+    <div
+      style={{
+        background: 'rgba(255,255,255,0.04)',
+        borderRadius: 10,
+        padding: '10px 8px',
+        textAlign: 'center',
+      }}
+    >
+      <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', marginBottom: 2 }}>{label}</div>
+      <div style={{ fontSize: 14, fontWeight: 700, color }}>{value}</div>
+    </div>
+  );
+}

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -7,6 +7,7 @@ import { useHabitStore } from '@/stores/habit-store';
 import { useInventoryStore } from '@/stores/inventory-store';
 import { useGameStore } from '@/stores/game-store';
 import { formatDateString, isScheduledForDate } from '@/lib/schedule-utils';
+import { shouldTriggerWeeklyReport, generateAndAwardWeeklyReport } from '@/lib/weekly-report-engine';
 
 export default function AppInitializer() {
   useEffect(() => {
@@ -23,6 +24,25 @@ export default function AppInitializer() {
       if (isFirstUse) {
         useGameStore.getState().setShowOnboarding(true);
         return;
+      }
+
+      // Check if weekly report should trigger (before auto-open check-in)
+      const { trigger, weekStart } = shouldTriggerWeeklyReport(new Date());
+      if (trigger) {
+        const existing = await db.weeklySnapshots
+          .where('weekStart')
+          .equals(weekStart)
+          .first();
+        if (!existing || !existing.delivered) {
+          try {
+            const snapshot = await generateAndAwardWeeklyReport(weekStart);
+            useGameStore.getState().setWeeklyReportSnapshot(snapshot);
+            useGameStore.getState().openScreen('weekly-report');
+            return; // Don't auto-open check-in — show report first
+          } catch {
+            // Silently continue if report generation fails
+          }
+        }
       }
 
       // Auto-open check-in if there are pending habits and user hasn't dismissed

--- a/src/components/CircularProgress.tsx
+++ b/src/components/CircularProgress.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+interface CircularProgressProps {
+  percentage: number;
+  size?: number;
+  strokeWidth?: number;
+  color?: string;
+}
+
+export default function CircularProgress({
+  percentage,
+  size = 140,
+  strokeWidth = 10,
+  color,
+}: CircularProgressProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (Math.min(percentage, 100) / 100) * circumference;
+
+  const resolvedColor =
+    color ?? (percentage >= 80 ? '#10B981' : percentage >= 60 ? '#F59E0B' : '#EF4444');
+
+  return (
+    <div style={{ position: 'relative', width: size, height: size }}>
+      <svg width={size} height={size} style={{ transform: 'rotate(-90deg)' }}>
+        {/* Background track */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="rgba(255,255,255,0.1)"
+          strokeWidth={strokeWidth}
+        />
+        {/* Progress arc */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={resolvedColor}
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          style={{ transition: 'stroke-dashoffset 0.8s ease' }}
+        />
+      </svg>
+      {/* Center text */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+        }}
+      >
+        <span style={{ fontSize: size * 0.28, fontWeight: 800, color: 'white', lineHeight: 1 }}>
+          {percentage}%
+        </span>
+        <span style={{ fontSize: size * 0.1, color: 'rgba(255,255,255,0.5)', marginTop: 2 }}>
+          completed
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HabitForm.tsx
+++ b/src/components/HabitForm.tsx
@@ -59,8 +59,8 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
         ...(freqType === 'specific_days' && { specificDays }),
       },
       timeOfDay,
-      startDate: showDates && startDate ? new Date(startDate + 'T00:00:00').toISOString() : undefined,
-      endDate: showDates && endDate ? new Date(endDate + 'T00:00:00').toISOString() : undefined,
+      startDate: showDates && startDate ? startDate : undefined,
+      endDate: showDates && endDate ? endDate : undefined,
     };
 
     if (mode === 'edit' && habit) {
@@ -302,12 +302,24 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
               </div>
               <div>
                 <span className="text-xs text-gray-500">End (optional)</span>
-                <input
-                  type="date"
-                  value={endDate}
-                  onChange={(e) => setEndDate(e.target.value)}
-                  className="w-full bg-gray-800 text-white rounded-lg px-3 py-2 text-sm outline-none mt-1"
-                />
+                <div className="relative mt-1">
+                  <input
+                    type="date"
+                    value={endDate}
+                    onChange={(e) => setEndDate(e.target.value)}
+                    className="w-full bg-gray-800 text-white rounded-lg px-3 py-2 text-sm outline-none"
+                  />
+                  {endDate && (
+                    <button
+                      type="button"
+                      onClick={() => setEndDate('')}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 active:text-white text-lg leading-none"
+                      aria-label="Clear end date"
+                    >
+                      &times;
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
           )}

--- a/src/components/MonthlyStats.tsx
+++ b/src/components/MonthlyStats.tsx
@@ -1,0 +1,430 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronLeft, ChevronRight, TrendingUp, TrendingDown, Minus, Zap, Coins } from 'lucide-react';
+import { db } from '@/db/db';
+import { useHabitStore } from '@/stores/habit-store';
+import { isScheduledForDate, formatDateString } from '@/lib/schedule-utils';
+import type { CheckIn } from '@/types/check-in';
+import type { Habit } from '@/types/habit';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface DayData {
+  date: string;
+  inMonth: boolean;
+  scheduled: number;
+  completed: number;
+  rate: number; // 0-100
+  habitDetails: { name: string; completed: boolean }[];
+}
+
+interface HabitRate {
+  name: string;
+  completed: number;
+  scheduled: number;
+  rate: number;
+}
+
+interface MonthData {
+  days: DayData[];
+  habitRates: HabitRate[];
+  totalXP: number;
+  totalCoins: number;
+  overallRate: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getMonthGrid(year: number, month: number): { date: string; inMonth: boolean }[] {
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+
+  // Monday-based week: 0=Mon, 6=Sun
+  let startDow = firstDay.getDay() - 1;
+  if (startDow < 0) startDow = 6;
+
+  const cells: { date: string; inMonth: boolean }[] = [];
+
+  // Fill leading days from previous month
+  for (let i = startDow - 1; i >= 0; i--) {
+    const d = new Date(year, month, -i);
+    cells.push({ date: formatDateString(d), inMonth: false });
+  }
+
+  // Current month days
+  for (let d = 1; d <= lastDay.getDate(); d++) {
+    cells.push({ date: formatDateString(new Date(year, month, d)), inMonth: true });
+  }
+
+  // Fill trailing to complete last row
+  while (cells.length % 7 !== 0) {
+    const d = new Date(year, month + 1, cells.length - startDow - lastDay.getDate() + 1);
+    cells.push({ date: formatDateString(d), inMonth: false });
+  }
+
+  return cells;
+}
+
+function computeMonthData(
+  year: number,
+  month: number,
+  habits: Habit[],
+  checkIns: CheckIn[],
+): MonthData {
+  const grid = getMonthGrid(year, month);
+  const today = formatDateString(new Date());
+
+  const checkInMap = new Map<string, Set<string>>();
+  let totalXP = 0;
+  let totalCoins = 0;
+
+  for (const ci of checkIns) {
+    if (ci.completed) {
+      const key = ci.date;
+      if (!checkInMap.has(key)) checkInMap.set(key, new Set());
+      checkInMap.get(key)!.add(ci.habitId);
+      totalXP += ci.xpEarned;
+      totalCoins += ci.coinsEarned;
+    }
+  }
+
+  let monthScheduled = 0;
+  let monthCompleted = 0;
+
+  // Per-habit tracking for month
+  const habitStats = new Map<string, { name: string; completed: number; scheduled: number }>();
+  for (const h of habits) {
+    habitStats.set(h.id, { name: h.name, completed: 0, scheduled: 0 });
+  }
+
+  const days: DayData[] = grid.map((cell) => {
+    if (!cell.inMonth || cell.date > today) {
+      return { ...cell, scheduled: 0, completed: 0, rate: -1, habitDetails: [] };
+    }
+
+    const scheduled = habits.filter((h) => isScheduledForDate(h, cell.date));
+    const completedIds = checkInMap.get(cell.date) ?? new Set();
+    const completedCount = scheduled.filter((h) => completedIds.has(h.id)).length;
+
+    monthScheduled += scheduled.length;
+    monthCompleted += completedCount;
+
+    for (const h of scheduled) {
+      const stats = habitStats.get(h.id);
+      if (stats) {
+        stats.scheduled++;
+        if (completedIds.has(h.id)) stats.completed++;
+      }
+    }
+
+    const rate = scheduled.length > 0 ? Math.round((completedCount / scheduled.length) * 100) : -1;
+
+    return {
+      ...cell,
+      scheduled: scheduled.length,
+      completed: completedCount,
+      rate,
+      habitDetails: scheduled.map((h) => ({
+        name: h.name,
+        completed: completedIds.has(h.id),
+      })),
+    };
+  });
+
+  const habitRates: HabitRate[] = [];
+  for (const stats of habitStats.values()) {
+    if (stats.scheduled > 0) {
+      habitRates.push({
+        ...stats,
+        rate: Math.round((stats.completed / stats.scheduled) * 100),
+      });
+    }
+  }
+  habitRates.sort((a, b) => b.rate - a.rate);
+
+  const overallRate = monthScheduled > 0 ? Math.round((monthCompleted / monthScheduled) * 100) : 0;
+
+  return { days, habitRates, totalXP, totalCoins, overallRate };
+}
+
+function getDayCellColor(rate: number, inMonth: boolean): string {
+  if (!inMonth || rate < 0) return 'transparent';
+  if (rate === 100) return 'rgba(16, 185, 129, 0.5)';   // dark green
+  if (rate >= 70) return 'rgba(16, 185, 129, 0.3)';     // medium green
+  if (rate >= 50) return 'rgba(16, 185, 129, 0.15)';    // light green
+  if (rate > 0) return 'rgba(255, 255, 255, 0.06)';     // light grey
+  return 'rgba(255, 255, 255, 0.02)';                    // empty
+}
+
+const WEEKDAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function MonthlyStats() {
+  const habits = useHabitStore((s) => s.habits);
+  const [year, setYear] = useState(() => new Date().getFullYear());
+  const [month, setMonth] = useState(() => new Date().getMonth());
+  const [data, setData] = useState<MonthData | null>(null);
+  const [prevRate, setPrevRate] = useState<number | null>(null);
+  const [tooltip, setTooltip] = useState<DayData | null>(null);
+
+  // Load data for selected month
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const firstDate = formatDateString(new Date(year, month, 1));
+      const lastDate = formatDateString(new Date(year, month + 1, 0));
+
+      const checkIns = await db.checkIns
+        .where('date')
+        .between(firstDate, lastDate, true, true)
+        .toArray();
+
+      if (cancelled) return;
+      setData(computeMonthData(year, month, habits, checkIns));
+
+      // Load previous month for trend
+      const prevYear = month === 0 ? year - 1 : year;
+      const prevMonth = month === 0 ? 11 : month - 1;
+      const prevFirst = formatDateString(new Date(prevYear, prevMonth, 1));
+      const prevLast = formatDateString(new Date(prevYear, prevMonth + 1, 0));
+      const prevCheckIns = await db.checkIns
+        .where('date')
+        .between(prevFirst, prevLast, true, true)
+        .toArray();
+
+      if (cancelled) return;
+      const prevData = computeMonthData(prevYear, prevMonth, habits, prevCheckIns);
+      setPrevRate(prevData.overallRate);
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [year, month, habits]);
+
+  const goPrev = useCallback(() => {
+    setTooltip(null);
+    if (month === 0) { setYear(year - 1); setMonth(11); }
+    else setMonth(month - 1);
+  }, [year, month]);
+
+  const goNext = useCallback(() => {
+    setTooltip(null);
+    const now = new Date();
+    if (year === now.getFullYear() && month === now.getMonth()) return;
+    if (month === 11) { setYear(year + 1); setMonth(0); }
+    else setMonth(month + 1);
+  }, [year, month]);
+
+  const isCurrentMonth = year === new Date().getFullYear() && month === new Date().getMonth();
+  const monthLabel = new Date(year, month).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+
+  if (!data) {
+    return (
+      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(255,255,255,0.3)' }}>
+        Loading...
+      </div>
+    );
+  }
+
+  const trendDiff = prevRate !== null ? data.overallRate - prevRate : null;
+
+  return (
+    <div style={{ padding: '12px 16px 24px', display: 'flex', flexDirection: 'column', gap: 24 }}>
+      {/* Month navigation */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <button
+          onClick={goPrev}
+          style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4 }}
+        >
+          <ChevronLeft size={20} color="rgba(255,255,255,0.6)" />
+        </button>
+        <span style={{ fontSize: 16, fontWeight: 600, color: 'white' }}>{monthLabel}</span>
+        <button
+          onClick={goNext}
+          style={{
+            background: 'none',
+            border: 'none',
+            cursor: isCurrentMonth ? 'default' : 'pointer',
+            padding: 4,
+            opacity: isCurrentMonth ? 0.3 : 1,
+          }}
+          disabled={isCurrentMonth}
+        >
+          <ChevronRight size={20} color="rgba(255,255,255,0.6)" />
+        </button>
+      </div>
+
+      {/* Calendar heatmap */}
+      <div>
+        {/* Weekday headers */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 3, marginBottom: 4 }}>
+          {WEEKDAY_LABELS.map((d) => (
+            <div key={d} style={{ textAlign: 'center', fontSize: 10, color: 'rgba(255,255,255,0.3)', fontWeight: 500 }}>
+              {d}
+            </div>
+          ))}
+        </div>
+        {/* Day cells */}
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 3 }}>
+          {data.days.map((day) => {
+            const dayNum = parseInt(day.date.slice(8), 10);
+            return (
+              <button
+                key={day.date}
+                onClick={() => day.inMonth && day.rate >= 0 ? setTooltip(tooltip?.date === day.date ? null : day) : null}
+                style={{
+                  aspectRatio: '1',
+                  borderRadius: 6,
+                  border: 'none',
+                  background: getDayCellColor(day.rate, day.inMonth),
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: day.inMonth && day.rate >= 0 ? 'pointer' : 'default',
+                  fontSize: 11,
+                  fontWeight: 500,
+                  color: day.inMonth ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.15)',
+                  outline: tooltip?.date === day.date ? '2px solid rgba(59,130,246,0.5)' : 'none',
+                }}
+              >
+                {dayNum}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Day tooltip */}
+      {tooltip && (
+        <div
+          style={{
+            background: 'rgba(255,255,255,0.06)',
+            borderRadius: 10,
+            padding: '10px 14px',
+            border: '1px solid rgba(255,255,255,0.08)',
+          }}
+        >
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'white', marginBottom: 6 }}>
+            {new Date(tooltip.date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            {' — '}
+            {tooltip.completed}/{tooltip.scheduled} ({tooltip.rate}%)
+          </div>
+          {tooltip.habitDetails.map((h) => (
+            <div key={h.name} style={{ fontSize: 12, color: 'rgba(255,255,255,0.5)', marginLeft: 4, marginBottom: 2 }}>
+              {h.completed ? '\u2705' : '\u2B1C'} {h.name}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Per-habit completion rates */}
+      {data.habitRates.length > 0 && (
+        <section>
+          <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(255,255,255,0.7)', margin: '0 0 12px' }}>
+            Per-Habit Rates
+          </h2>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            {data.habitRates.map((h) => (
+              <div key={h.name}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4, fontSize: 13 }}>
+                  <span style={{ color: 'white' }}>{h.name}</span>
+                  <span style={{ color: 'rgba(255,255,255,0.5)' }}>
+                    {h.completed}/{h.scheduled} ({h.rate}%)
+                  </span>
+                </div>
+                <div style={{ height: 6, borderRadius: 3, background: 'rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${h.rate}%`,
+                      borderRadius: 3,
+                      background: h.rate >= 80 ? '#10B981' : h.rate >= 60 ? '#F59E0B' : '#EF4444',
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Trend vs last month */}
+      {trendDiff !== null && (
+        <section
+          style={{
+            background: 'rgba(255,255,255,0.04)',
+            borderRadius: 14,
+            padding: '14px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+          }}
+        >
+          {trendDiff > 1 ? (
+            <TrendingUp size={20} color="#10B981" />
+          ) : trendDiff < -1 ? (
+            <TrendingDown size={20} color="#EF4444" />
+          ) : (
+            <Minus size={20} color="#F59E0B" />
+          )}
+          <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.6)' }}>
+            <span style={{ color: 'white', fontWeight: 600 }}>{data.overallRate}%</span> this month
+            {' vs '}
+            <span style={{ color: 'white', fontWeight: 600 }}>{prevRate}%</span> last month
+            {trendDiff !== 0 && (
+              <span style={{ color: trendDiff > 0 ? '#10B981' : '#EF4444', fontWeight: 600 }}>
+                {' '}({trendDiff > 0 ? '+' : ''}{trendDiff}%)
+              </span>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Monthly XP + Coins */}
+      <section
+        style={{
+          display: 'flex',
+          gap: 12,
+        }}
+      >
+        <div
+          style={{
+            flex: 1,
+            background: 'rgba(255,255,255,0.04)',
+            borderRadius: 14,
+            padding: '14px 16px',
+            textAlign: 'center',
+          }}
+        >
+          <Zap size={18} color="#3b82f6" style={{ marginBottom: 4 }} />
+          <div style={{ fontSize: 18, fontWeight: 700, color: '#3b82f6' }}>
+            {data.totalXP.toLocaleString()}
+          </div>
+          <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>XP earned</div>
+        </div>
+        <div
+          style={{
+            flex: 1,
+            background: 'rgba(255,255,255,0.04)',
+            borderRadius: 14,
+            padding: '14px 16px',
+            textAlign: 'center',
+          }}
+        >
+          <Coins size={18} color="#facc15" style={{ marginBottom: 4 }} />
+          <div style={{ fontSize: 18, fontWeight: 700, color: '#facc15' }}>
+            {data.totalCoins.toLocaleString()}
+          </div>
+          <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>Coins earned</div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/StatsScreen.tsx
+++ b/src/components/StatsScreen.tsx
@@ -1,37 +1,99 @@
 'use client';
 
-import { X, BarChart3 } from 'lucide-react';
+import { useState } from 'react';
+import { X } from 'lucide-react';
 import { useGameStore } from '@/stores/game-store';
+import MonthlyStats from './MonthlyStats';
+import AllTimeStats from './AllTimeStats';
+
+type StatsTab = 'monthly' | 'all-time';
+
+const TABS: { key: StatsTab; label: string }[] = [
+  { key: 'monthly', label: 'Monthly' },
+  { key: 'all-time', label: 'All Time' },
+];
 
 export default function StatsScreen() {
   const activeScreen = useGameStore((s) => s.activeScreen);
+  const [tab, setTab] = useState<StatsTab>('monthly');
 
   if (activeScreen !== 'stats') return null;
 
   return (
     <div
-      className="fixed inset-0 flex flex-col"
       style={{
+        position: 'fixed',
+        inset: 0,
         zIndex: 150,
         background: 'rgba(10, 12, 20, 0.97)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
       }}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 pt-4 pb-3">
-        <h1 className="text-lg font-semibold text-white">Stats</h1>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: 'max(env(safe-area-inset-top), 12px) 16px 10px',
+        }}
+      >
+        <h1 style={{ fontSize: 20, fontWeight: 700, color: 'white', margin: 0 }}>Stats</h1>
         <button
           onClick={() => useGameStore.getState().openScreen('city')}
-          className="p-1 text-gray-400 active:text-white"
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: '50%',
+            border: 'none',
+            background: 'rgba(255,255,255,0.08)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+          }}
           aria-label="Close"
         >
-          <X size={22} />
+          <X size={20} color="rgba(255,255,255,0.6)" />
         </button>
       </div>
 
-      {/* Body */}
-      <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-8">
-        <BarChart3 size={48} className="text-blue-500/40" />
-        <p className="text-gray-400 text-sm">Stats &amp; analytics coming soon.</p>
+      {/* Tab bar */}
+      <div
+        style={{
+          display: 'flex',
+          gap: 4,
+          padding: '0 16px 12px',
+          background: 'rgba(255,255,255,0.02)',
+        }}
+      >
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            style={{
+              flex: 1,
+              padding: '8px 0',
+              borderRadius: 8,
+              border: 'none',
+              background: tab === t.key ? 'rgba(255,255,255,0.1)' : 'transparent',
+              color: tab === t.key ? 'white' : 'rgba(255,255,255,0.4)',
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: 'pointer',
+              transition: 'all 0.2s ease',
+            }}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {tab === 'monthly' ? <MonthlyStats /> : <AllTimeStats />}
       </div>
     </div>
   );

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -1,0 +1,275 @@
+'use client';
+
+import { useCallback } from 'react';
+import { X, TrendingUp, Zap, Coins } from 'lucide-react';
+import { useGameStore } from '@/stores/game-store';
+import CircularProgress from './CircularProgress';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDateRange(weekStart: string): string {
+  const start = new Date(weekStart + 'T00:00:00');
+  const end = new Date(start);
+  end.setDate(end.getDate() + 6);
+
+  const opts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
+  return `${start.toLocaleDateString('en-US', opts)} – ${end.toLocaleDateString('en-US', opts)}`;
+}
+
+// ---------------------------------------------------------------------------
+// WeeklyReport
+// ---------------------------------------------------------------------------
+
+export default function WeeklyReport() {
+  const activeScreen = useGameStore((s) => s.activeScreen);
+  const snapshot = useGameStore((s) => s.weeklyReportSnapshot);
+
+  const handleDismiss = useCallback(() => {
+    const store = useGameStore.getState();
+    // Queue the weekly bonus reward animation
+    if (snapshot && (snapshot.bonusXPEarned > 0 || snapshot.bonusCoinEarned > 0)) {
+      store.queueReward({
+        type: 'weekly-bonus',
+        payload: {
+          xp: snapshot.bonusXPEarned,
+          coins: snapshot.bonusCoinEarned,
+          percentage: snapshot.completionPercentage,
+        },
+      });
+    }
+    store.setWeeklyReportSnapshot(null);
+    store.openScreen('city');
+  }, [snapshot]);
+
+  if (activeScreen !== 'weekly-report' || !snapshot) return null;
+
+  const sortedHabits = [...snapshot.perHabitBreakdown].sort((a, b) => {
+    const rateA = a.scheduled > 0 ? a.completed / a.scheduled : 0;
+    const rateB = b.scheduled > 0 ? b.completed / b.scheduled : 0;
+    return rateB - rateA;
+  });
+
+  const totalXP = snapshot.baseXPEarned + snapshot.bonusXPEarned;
+  const totalCoins = snapshot.baseCoinEarned + snapshot.bonusCoinEarned;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 150,
+        background: 'rgba(10, 12, 20, 0.97)',
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: 'max(env(safe-area-inset-top), 12px) 16px 10px',
+        }}
+      >
+        <div>
+          <h1 style={{ fontSize: 20, fontWeight: 700, color: 'white', margin: 0 }}>
+            Weekly City Report
+          </h1>
+          <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.5)' }}>
+            {formatDateRange(snapshot.weekStart)}
+          </span>
+        </div>
+        <button
+          onClick={handleDismiss}
+          style={{
+            width: 36,
+            height: 36,
+            borderRadius: '50%',
+            border: 'none',
+            background: 'rgba(255,255,255,0.08)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+          }}
+          aria-label="Close"
+        >
+          <X size={20} color="rgba(255,255,255,0.6)" />
+        </button>
+      </div>
+
+      {/* Scrollable body */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: '16px 16px max(env(safe-area-inset-bottom), 16px)',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 24,
+        }}
+      >
+        {/* Completion ring */}
+        <div style={{ display: 'flex', justifyContent: 'center', padding: '8px 0' }}>
+          <CircularProgress percentage={snapshot.completionPercentage} size={160} strokeWidth={12} />
+        </div>
+
+        {/* Summary line */}
+        <div style={{ textAlign: 'center', color: 'rgba(255,255,255,0.6)', fontSize: 14 }}>
+          {snapshot.totalCompleted} of {snapshot.totalScheduled} habits completed
+        </div>
+
+        {/* Per-habit breakdown */}
+        {sortedHabits.length > 0 && (
+          <section>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(255,255,255,0.7)', margin: '0 0 12px' }}>
+              Habit Breakdown
+            </h2>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {sortedHabits.map((h) => {
+                const rate = h.scheduled > 0 ? Math.round((h.completed / h.scheduled) * 100) : 0;
+                return (
+                  <div key={h.habitId}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        marginBottom: 4,
+                        fontSize: 13,
+                      }}
+                    >
+                      <span style={{ color: 'white' }}>{h.habitName}</span>
+                      <span style={{ color: 'rgba(255,255,255,0.5)' }}>
+                        {h.completed}/{h.scheduled} ({rate}%)
+                      </span>
+                    </div>
+                    <div
+                      style={{
+                        height: 6,
+                        borderRadius: 3,
+                        background: 'rgba(255,255,255,0.08)',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      <div
+                        style={{
+                          height: '100%',
+                          width: `${rate}%`,
+                          borderRadius: 3,
+                          background:
+                            rate >= 80 ? '#10B981' : rate >= 60 ? '#F59E0B' : '#EF4444',
+                          transition: 'width 0.5s ease',
+                        }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* XP Earned */}
+        <section
+          style={{
+            background: 'rgba(255,255,255,0.04)',
+            borderRadius: 14,
+            padding: '14px 16px',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+            <Zap size={18} color="#3b82f6" />
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'white', margin: 0 }}>
+              XP Earned
+            </h2>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 4 }}>
+            <span>Base tasks</span>
+            <span>+{snapshot.baseXPEarned.toLocaleString()} XP</span>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 8 }}>
+            <span>Weekly bonus ({snapshot.consistencyTier})</span>
+            <span>+{snapshot.bonusXPEarned.toLocaleString()} XP</span>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 16, fontWeight: 700, color: '#3b82f6' }}>
+            <span>Total</span>
+            <span>+{totalXP.toLocaleString()} XP</span>
+          </div>
+        </section>
+
+        {/* Coins Earned */}
+        <section
+          style={{
+            background: 'rgba(255,255,255,0.04)',
+            borderRadius: 14,
+            padding: '14px 16px',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+            <Coins size={18} color="#facc15" />
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'white', margin: 0 }}>
+              Coins Earned
+            </h2>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 4 }}>
+            <span>Base tasks</span>
+            <span>+{snapshot.baseCoinEarned.toLocaleString()}</span>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 8 }}>
+            <span>Weekly bonus ({snapshot.consistencyTier})</span>
+            <span>+{snapshot.bonusCoinEarned.toLocaleString()}</span>
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 16, fontWeight: 700, color: '#facc15' }}>
+            <span>Total</span>
+            <span>+{totalCoins.toLocaleString()}</span>
+          </div>
+        </section>
+
+        {/* Weekly Bonus Reveal */}
+        <section
+          style={{
+            background: 'linear-gradient(135deg, rgba(139,92,246,0.15), rgba(59,130,246,0.15))',
+            border: '1px solid rgba(139,92,246,0.2)',
+            borderRadius: 14,
+            padding: '20px 16px',
+            textAlign: 'center',
+          }}
+        >
+          <TrendingUp size={28} color="#8b5cf6" style={{ marginBottom: 8 }} />
+          <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)', marginBottom: 4 }}>
+            Consistency Bonus
+          </div>
+          <div style={{ fontSize: 32, fontWeight: 800, color: '#8b5cf6', lineHeight: 1.1 }}>
+            {snapshot.consistencyTier} Bonus!
+          </div>
+          <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.5)', marginTop: 8 }}>
+            +{snapshot.bonusXPEarned.toLocaleString()} XP &middot; +{snapshot.bonusCoinEarned.toLocaleString()} Coins
+          </div>
+        </section>
+
+        {/* Dismiss button */}
+        <button
+          onClick={handleDismiss}
+          style={{
+            width: '100%',
+            padding: '14px 0',
+            borderRadius: 12,
+            border: 'none',
+            background: 'linear-gradient(135deg, #8b5cf6, #6366f1)',
+            color: 'white',
+            fontSize: 16,
+            fontWeight: 600,
+            cursor: 'pointer',
+            marginTop: 8,
+          }}
+        >
+          Back to City
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeeklyView.tsx
+++ b/src/components/WeeklyView.tsx
@@ -111,8 +111,18 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
     const percentage = totalScheduled > 0 ? Math.round((totalCompleted / totalScheduled) * 100) : 0;
     const multiplier = getWeeklyBonusMultiplier(percentage);
 
-    return { totalScheduled, totalCompleted, percentage, multiplier };
-  }, [displayDates, lastCountableDay, scheduledByDay, completedSet]);
+    // Sum XP and coins earned this week from check-ins
+    let xpEarned = 0;
+    let coinsEarned = 0;
+    for (const ci of checkIns) {
+      if (ci.completed) {
+        xpEarned += ci.xpEarned;
+        coinsEarned += ci.coinsEarned;
+      }
+    }
+
+    return { totalScheduled, totalCompleted, percentage, multiplier, xpEarned, coinsEarned };
+  }, [displayDates, lastCountableDay, scheduledByDay, completedSet, checkIns]);
 
   // Auto-scroll today's column into center view (current week only)
   useEffect(() => {
@@ -296,6 +306,11 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
               : 'No bonus yet'}
           </div>
         </div>
+        {(weeklyStats.xpEarned > 0 || weeklyStats.coinsEarned > 0) && (
+          <div className="text-xs text-gray-500 mt-1.5">
+            +{weeklyStats.xpEarned.toLocaleString()} XP &middot; +{weeklyStats.coinsEarned.toLocaleString()} Coins this week
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -112,4 +112,18 @@ db.version(5).stores({
   weeklySnapshots: 'id, weekStart',
 });
 
+db.version(6).stores({
+  city: 'id',
+  roads: 'id',
+  sidewalks: 'id',
+  accessories: 'id',
+  gameState: 'id',
+  habits: 'id, archived',
+  checkIns: 'id, [habitId+date], date',
+  playerProfile: 'id',
+  inventory: 'id, assetId',
+  placedAssets: 'id, assetId',
+  weeklySnapshots: 'id, weekStart',
+});
+
 export { db };

--- a/src/lib/schedule-utils.ts
+++ b/src/lib/schedule-utils.ts
@@ -15,7 +15,9 @@ export function formatDateString(d: Date): string {
  * Respects start/end date bounds and frequency config.
  */
 export function isScheduledForDate(habit: Habit, dateStr: string): boolean {
-  if (habit.startDate && dateStr < habit.startDate.slice(0, 10)) return false;
+  // Use startDate if set, otherwise fall back to createdAt
+  const effectiveStart = habit.startDate ?? habit.createdAt;
+  if (effectiveStart && dateStr < effectiveStart.slice(0, 10)) return false;
   if (habit.endDate && dateStr > habit.endDate.slice(0, 10)) return false;
 
   const freq = habit.frequency;

--- a/src/lib/weekly-engine.ts
+++ b/src/lib/weekly-engine.ts
@@ -155,6 +155,19 @@ export function generateWeeklySnapshot(
   const multiplier = getWeeklyBonusMultiplier(completion.percentage);
   const bonus = calculateWeeklyBonus(baseXPEarned, baseCoinEarned, multiplier);
 
+  const habitMap = new Map(habits.map((h) => [h.id, h]));
+  const perHabitBreakdown: WeeklySnapshot['perHabitBreakdown'] = [];
+  for (const [habitId, stats] of completion.perHabit) {
+    if (stats.scheduled === 0) continue;
+    const habit = habitMap.get(habitId);
+    perHabitBreakdown.push({
+      habitId,
+      habitName: habit?.name ?? 'Unknown',
+      completed: stats.completed,
+      scheduled: stats.scheduled,
+    });
+  }
+
   const now = new Date().toISOString();
 
   return {
@@ -168,6 +181,8 @@ export function generateWeeklySnapshot(
     bonusXPEarned: bonus.xp,
     bonusCoinEarned: bonus.coins,
     consistencyTier: `${multiplier}x`,
+    delivered: false,
+    perHabitBreakdown,
     createdAt: now,
     updatedAt: now,
   };

--- a/src/lib/weekly-report-engine.ts
+++ b/src/lib/weekly-report-engine.ts
@@ -1,0 +1,111 @@
+import { formatDateString } from '@/lib/schedule-utils';
+import { generateWeeklySnapshot } from '@/lib/weekly-engine';
+import { db } from '@/db/db';
+import { usePlayerStore } from '@/stores/player-store';
+import type { WeeklySnapshot } from '@/types/weekly-snapshot';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the Monday (ISO date) of the most recently completed week.
+ * A week is "completed" once Sunday 21:00 has passed.
+ */
+export function getCompletedWeekStart(now: Date): string {
+  const day = now.getDay(); // 0=Sun, 1=Mon, ...
+  const hour = now.getHours();
+
+  // If Sunday >= 21:00, the just-ended week's Monday is 6 days ago
+  // Otherwise, the completed week is the one before the current week
+  let daysBack: number;
+
+  if (day === 0 && hour >= 21) {
+    // Sunday after 9pm — this week just ended
+    daysBack = 6;
+  } else if (day === 0) {
+    // Sunday before 9pm — previous week
+    daysBack = 13;
+  } else {
+    // Mon-Sat — previous week's Monday
+    // Current week's Monday is (day - 1) days ago
+    // Previous week's Monday is (day - 1 + 7) days ago
+    daysBack = day - 1 + 7;
+  }
+
+  const monday = new Date(now);
+  monday.setHours(0, 0, 0, 0);
+  monday.setDate(monday.getDate() - daysBack);
+  return formatDateString(monday);
+}
+
+/**
+ * Determine if the weekly report should trigger.
+ */
+export function shouldTriggerWeeklyReport(now: Date): { trigger: boolean; weekStart: string } {
+  const day = now.getDay();
+  const hour = now.getHours();
+
+  // Only trigger after Sunday 21:00 (or any day in the following week)
+  // Effectively: always trigger — the real guard is whether a delivered snapshot exists
+  const isSundayBefore9pm = day === 0 && hour < 21;
+
+  if (isSundayBefore9pm) {
+    // Too early — current week hasn't ended yet, check previous week
+  }
+
+  const weekStart = getCompletedWeekStart(now);
+  return { trigger: true, weekStart };
+}
+
+/**
+ * Generate the weekly snapshot, award bonuses, and save to DB.
+ */
+export async function generateAndAwardWeeklyReport(weekStart: string): Promise<WeeklySnapshot> {
+  // Load all habits (including archived — they may have been active during the week)
+  const allHabits = await db.habits.toArray();
+  // Filter to habits that existed before or during the week
+  const weekEndDate = new Date(weekStart + 'T00:00:00');
+  weekEndDate.setDate(weekEndDate.getDate() + 6);
+  const weekEnd = formatDateString(weekEndDate);
+
+  const habits = allHabits.filter((h) => {
+    // Include if habit was created before or during the week
+    const created = h.createdAt.slice(0, 10);
+    return created <= weekEnd;
+  });
+
+  // Load check-ins for the week
+  const checkIns = await db.checkIns
+    .where('date')
+    .between(weekStart, weekEnd, true, true)
+    .toArray();
+
+  // Sum base earnings from check-ins
+  let baseXP = 0;
+  let baseCoins = 0;
+  for (const ci of checkIns) {
+    if (ci.completed) {
+      baseXP += ci.xpEarned;
+      baseCoins += ci.coinsEarned;
+    }
+  }
+
+  // Generate the snapshot
+  const snapshot = generateWeeklySnapshot(weekStart, habits, checkIns, baseXP, baseCoins);
+  snapshot.delivered = true;
+
+  // Save to DB (fire-and-forget pattern)
+  db.weeklySnapshots.put(snapshot).catch(() => {});
+
+  // Award bonus XP and coins
+  const playerStore = usePlayerStore.getState();
+  if (snapshot.bonusXPEarned > 0) {
+    playerStore.addXP(snapshot.bonusXPEarned);
+  }
+  if (snapshot.bonusCoinEarned > 0) {
+    playerStore.addCoins(snapshot.bonusCoinEarned);
+  }
+
+  return snapshot;
+}

--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { GAME_CONFIG } from '@/config/game-config';
 import { usePlayerStore } from './player-store';
 import type { GameMode, ActiveScreen, PendingReward } from '@/types/game';
+import type { WeeklySnapshot } from '@/types/weekly-snapshot';
 
 interface GameState {
   currentMode: GameMode;
@@ -12,6 +13,7 @@ interface GameState {
   firstWeekBoostActive: boolean;
   showOnboarding: boolean;
   showHabitList: boolean;
+  weeklyReportSnapshot: WeeklySnapshot | null;
   tutorialStep: number | null;
   initialized: boolean;
 
@@ -24,6 +26,7 @@ interface GameState {
   setDoubleXPEvent: (active: boolean) => void;
   setShowOnboarding: (show: boolean) => void;
   setShowHabitList: (show: boolean) => void;
+  setWeeklyReportSnapshot: (snapshot: WeeklySnapshot | null) => void;
   setTutorialStep: (step: number | null) => void;
 }
 
@@ -36,6 +39,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   firstWeekBoostActive: false,
   showOnboarding: false,
   showHabitList: false,
+  weeklyReportSnapshot: null,
   tutorialStep: null,
   initialized: false,
 
@@ -99,6 +103,10 @@ export const useGameStore = create<GameState>((set, get) => ({
 
   setShowHabitList: (show) => {
     set({ showHabitList: show });
+  },
+
+  setWeeklyReportSnapshot: (snapshot) => {
+    set({ weeklyReportSnapshot: snapshot });
   },
 
   setTutorialStep: (step) => {

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,6 +1,6 @@
 export type GameMode = 'view' | 'build' | 'check-in';
 
-export type ActiveScreen = 'city' | 'check-in' | 'stats' | 'shop' | 'settings';
+export type ActiveScreen = 'city' | 'check-in' | 'stats' | 'shop' | 'settings' | 'weekly-report';
 
 export interface PendingReward {
   type: 'level-up' | 'asset-unlock' | 'surprise-bonus' | 'weekly-bonus' | 'streak-milestone' | 'daily-perfect';

--- a/src/types/weekly-snapshot.ts
+++ b/src/types/weekly-snapshot.ts
@@ -1,3 +1,10 @@
+export interface WeeklySnapshotHabit {
+  habitId: string;
+  habitName: string;
+  completed: number;
+  scheduled: number;
+}
+
 export interface WeeklySnapshot {
   id: string;
   weekStart: string;           // ISO date string (Monday)
@@ -9,6 +16,8 @@ export interface WeeklySnapshot {
   bonusXPEarned: number;
   bonusCoinEarned: number;
   consistencyTier: string;
+  delivered: boolean;
+  perHabitBreakdown: WeeklySnapshotHabit[];
   createdAt: string;
   updatedAt: string;
   syncedAt?: string | null;


### PR DESCRIPTION
## Summary
- **Weekly City Report (6.1)**: Full-screen auto-triggered report after Sunday 21:00 showing completion %, per-habit breakdown, XP/coins earned, consistency bonus reveal with RewardReveal animation
- **Stats Screen: Monthly (6.2)**: Calendar heatmap with color-coded days, per-habit completion rates, trend vs last month, monthly XP/coins totals
- **Stats Screen: All Time (6.3)**: Level + XP bar, lifetime points, coins earned/spent/balance, longest streaks, total completions, city value
- **Weekly View footer**: Added XP and coins earned this week
- **Bug fix**: Habits no longer backfill to days before their creation date (uses `createdAt` as fallback when no `startDate` set)
- **Bug fix**: Date picker timezone shift — dates now stored as plain YYYY-MM-DD strings
- **Bug fix**: End date clear button added to habit form (iOS Reset unreliable)

Closes #55

## Test plan
- [ ] Weekly report triggers on first app open after Sunday 21:00
- [ ] Report does NOT re-trigger once delivered
- [ ] Bonus XP/coins awarded to player on report delivery
- [ ] RewardReveal animation fires on report dismiss
- [ ] Menu → Stats → Monthly: calendar heatmap renders, month nav works, tap day shows breakdown
- [ ] Menu → Stats → All Time: level, XP, coins, streaks, city value all accurate
- [ ] Weekly View footer shows "+X XP · +Y Coins this week"
- [ ] New habit only shows from creation date (not backfilled to earlier days)
- [ ] Start/end dates save correctly without timezone shift
- [ ] End date can be cleared via × button
- [ ] No regressions in check-in, shop, build mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)