### PR TITLE
Light mode conversion + dark/light theme toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,8 +2,8 @@
 
 
 body {
-  background: #1B4F8A;
-  color: #ffffff;
+  background: #F5F5FA;
+  color: #1a1a1a;
   font-family: Arial, Helvetica, sans-serif;
   -webkit-tap-highlight-color: transparent;
   user-select: none;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,98 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
+:root {
+  /* Page backgrounds */
+  --bg-body: #F5F5FA;
+  --bg-page: rgba(245, 245, 250, 0.97);
+
+  /* Card & surface backgrounds */
+  --bg-card: rgba(255, 255, 255, 0.6);
+  --bg-elevated: rgba(255, 255, 255, 0.8);
+  --bg-back-card: rgba(255, 255, 255, 0.4);
+
+  /* Glass backgrounds */
+  --bg-glass: rgba(255, 255, 255, 0.85);
+  --bg-hud: rgba(255, 255, 255, 0.75);
+  --bg-sheet: rgba(255, 255, 255, 0.92);
+  --bg-sheet-solid: rgba(255, 255, 255, 0.95);
+
+  /* Subtle backgrounds */
+  --bg-track: rgba(0, 0, 0, 0.08);
+  --bg-muted: rgba(0, 0, 0, 0.06);
+  --bg-subtle: rgba(0, 0, 0, 0.04);
+
+  /* Text colors */
+  --text-primary: #1a1a1a;
+  --text-secondary: #666666;
+  --text-muted: rgba(0, 0, 0, 0.35);
+  --text-icon: rgba(0, 0, 0, 0.45);
+  --text-faint: rgba(0, 0, 0, 0.25);
+  --text-label: rgba(0, 0, 0, 0.55);
+
+  /* Border colors */
+  --border: rgba(0, 0, 0, 0.08);
+  --border-subtle: rgba(0, 0, 0, 0.06);
+  --border-strong: rgba(0, 0, 0, 0.12);
+  --border-handle: rgba(0, 0, 0, 0.15);
+
+  /* Special colors */
+  --color-coin: #ca8a04;
+  --icon-fab: #444444;
+  --icon-build: #d97706;
+  --level-from: #7C3AED;
+  --level-to: #5B21B6;
+  --level-section: rgba(124, 58, 237, 0.08);
+}
+
+.dark {
+  /* Page backgrounds */
+  --bg-body: #0f172a;
+  --bg-page: rgba(10, 12, 20, 0.97);
+
+  /* Card & surface backgrounds */
+  --bg-card: rgb(31, 41, 55);
+  --bg-elevated: rgb(31, 41, 55);
+  --bg-back-card: rgba(31, 41, 55, 0.6);
+
+  /* Glass backgrounds */
+  --bg-glass: rgba(0, 0, 0, 0.6);
+  --bg-hud: rgba(10, 15, 30, 0.75);
+  --bg-sheet: rgba(15, 18, 30, 0.92);
+  --bg-sheet-solid: rgba(15, 18, 30, 0.95);
+
+  /* Subtle backgrounds */
+  --bg-track: rgba(255, 255, 255, 0.1);
+  --bg-muted: rgba(255, 255, 255, 0.1);
+  --bg-subtle: rgba(255, 255, 255, 0.06);
+
+  /* Text colors */
+  --text-primary: #ffffff;
+  --text-secondary: #9CA3AF;
+  --text-muted: #6B7280;
+  --text-icon: #9CA3AF;
+  --text-faint: rgba(255, 255, 255, 0.3);
+  --text-label: rgba(255, 255, 255, 0.7);
+
+  /* Border colors */
+  --border: rgba(255, 255, 255, 0.1);
+  --border-subtle: rgba(255, 255, 255, 0.06);
+  --border-strong: rgba(255, 255, 255, 0.15);
+  --border-handle: rgba(255, 255, 255, 0.2);
+
+  /* Special colors */
+  --color-coin: #facc15;
+  --icon-fab: #ffffff;
+  --icon-build: #fbbf24;
+  --level-from: #3b3478;
+  --level-to: #2a2060;
+  --level-section: rgba(59, 52, 120, 0.4);
+}
 
 body {
-  background: #F5F5FA;
-  color: #1a1a1a;
+  background: var(--bg-body);
+  color: var(--text-primary);
   font-family: Arial, Helvetica, sans-serif;
   -webkit-tap-highlight-color: transparent;
   user-select: none;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <meta name="theme-color" content="#89CFF0" />
         <link rel="manifest" href="/manifest.json" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,7 @@ export default function RootLayout({
       <head>
         <meta name="theme-color" content="#89CFF0" />
         <link rel="manifest" href="/manifest.json" />
+        <script dangerouslySetInnerHTML={{ __html: `(function(){try{var t=localStorage.getItem('habitville-theme');if(t==='dark'||(t==='system'&&matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})()` }} />
       </head>
       <body className="min-h-screen overflow-hidden" suppressHydrationWarning>
         <div

--- a/src/components/AllTimeStats.tsx
+++ b/src/components/AllTimeStats.tsx
@@ -86,7 +86,7 @@ export default function AllTimeStats() {
 
   if (!data) {
     return (
-      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(255,255,255,0.3)' }}>
+      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(0,0,0,0.25)' }}>
         Loading...
       </div>
     );
@@ -97,8 +97,8 @@ export default function AllTimeStats() {
       {/* Level + XP bar */}
       <section
         style={{
-          background: 'linear-gradient(135deg, rgba(59,52,120,0.4), rgba(42,32,96,0.4))',
-          border: '1px solid rgba(139,92,246,0.2)',
+          background: 'linear-gradient(135deg, rgba(124,58,237,0.08), rgba(91,33,182,0.08))',
+          border: '1px solid rgba(124,58,237,0.15)',
           borderRadius: 14,
           padding: '20px 16px',
           textAlign: 'center',
@@ -109,8 +109,8 @@ export default function AllTimeStats() {
             width: 56,
             height: 56,
             borderRadius: 14,
-            background: 'linear-gradient(135deg, #3b3478, #2a2060)',
-            border: '2px solid rgba(139,92,246,0.4)',
+            background: 'linear-gradient(135deg, #7C3AED, #5B21B6)',
+            border: '2px solid rgba(124,58,237,0.4)',
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',
@@ -118,7 +118,7 @@ export default function AllTimeStats() {
             margin: '0 auto 12px',
           }}
         >
-          <span style={{ fontSize: 10, fontWeight: 600, color: 'rgba(255,255,255,0.6)', lineHeight: 1 }}>LVL</span>
+          <span style={{ fontSize: 10, fontWeight: 600, color: 'rgba(255,255,255,0.8)', lineHeight: 1 }}>LVL</span>
           <span style={{ fontSize: 22, fontWeight: 800, color: 'white', lineHeight: 1.1 }}>{level}</span>
         </div>
 
@@ -128,7 +128,7 @@ export default function AllTimeStats() {
             style={{
               height: 8,
               borderRadius: 4,
-              background: 'rgba(255,255,255,0.1)',
+              background: 'rgba(0,0,0,0.08)',
               overflow: 'hidden',
               marginBottom: 6,
             }}
@@ -143,7 +143,7 @@ export default function AllTimeStats() {
               }}
             />
           </div>
-          <div style={{ fontSize: 12, color: 'rgba(255,255,255,0.5)' }}>
+          <div style={{ fontSize: 12, color: 'rgba(0,0,0,0.35)' }}>
             {progress.current.toLocaleString()} / {progress.required.toLocaleString()} XP to Level {level + 1}
           </div>
         </div>
@@ -175,7 +175,7 @@ export default function AllTimeStats() {
         <section>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12 }}>
             <Flame size={18} color="#f97316" />
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(255,255,255,0.7)', margin: 0 }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(0,0,0,0.55)', margin: 0 }}>
               Longest Streaks
             </h2>
           </div>
@@ -187,12 +187,12 @@ export default function AllTimeStats() {
                   display: 'flex',
                   justifyContent: 'space-between',
                   alignItems: 'center',
-                  background: 'rgba(255,255,255,0.04)',
+                  background: 'rgba(0,0,0,0.03)',
                   borderRadius: 10,
                   padding: '10px 14px',
                 }}
               >
-                <span style={{ fontSize: 13, color: 'white' }}>{s.name}</span>
+                <span style={{ fontSize: 13, color: '#1a1a1a' }}>{s.name}</span>
                 <span style={{ fontSize: 14, fontWeight: 700, color: '#f97316' }}>
                   {s.streak} days
                 </span>
@@ -239,7 +239,7 @@ function StatCard({
   return (
     <div
       style={{
-        background: 'rgba(255,255,255,0.04)',
+        background: 'rgba(0,0,0,0.03)',
         borderRadius: 14,
         padding: '14px 16px',
         display: 'flex',
@@ -249,7 +249,7 @@ function StatCard({
     >
       {icon}
       <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)', marginBottom: 2 }}>{label}</div>
+        <div style={{ fontSize: 11, color: 'rgba(0,0,0,0.35)', marginBottom: 2 }}>{label}</div>
         <div style={{ fontSize: 18, fontWeight: 700, color }}>{value}</div>
       </div>
     </div>
@@ -260,13 +260,13 @@ function MiniCard({ label, value, color }: { label: string; value: string; color
   return (
     <div
       style={{
-        background: 'rgba(255,255,255,0.04)',
+        background: 'rgba(0,0,0,0.03)',
         borderRadius: 10,
         padding: '10px 8px',
         textAlign: 'center',
       }}
     >
-      <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', marginBottom: 2 }}>{label}</div>
+      <div style={{ fontSize: 10, color: 'rgba(0,0,0,0.35)', marginBottom: 2 }}>{label}</div>
       <div style={{ fontSize: 14, fontWeight: 700, color }}>{value}</div>
     </div>
   );

--- a/src/components/AllTimeStats.tsx
+++ b/src/components/AllTimeStats.tsx
@@ -86,7 +86,7 @@ export default function AllTimeStats() {
 
   if (!data) {
     return (
-      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(0,0,0,0.25)' }}>
+      <div style={{ padding: 32, textAlign: 'center', color: 'var(--text-faint)' }}>
         Loading...
       </div>
     );
@@ -97,7 +97,7 @@ export default function AllTimeStats() {
       {/* Level + XP bar */}
       <section
         style={{
-          background: 'linear-gradient(135deg, rgba(124,58,237,0.08), rgba(91,33,182,0.08))',
+          background: 'linear-gradient(135deg, var(--level-section), rgba(91,33,182,0.08))',
           border: '1px solid rgba(124,58,237,0.15)',
           borderRadius: 14,
           padding: '20px 16px',
@@ -109,7 +109,7 @@ export default function AllTimeStats() {
             width: 56,
             height: 56,
             borderRadius: 14,
-            background: 'linear-gradient(135deg, #7C3AED, #5B21B6)',
+            background: 'linear-gradient(135deg, var(--level-from), var(--level-to))',
             border: '2px solid rgba(124,58,237,0.4)',
             display: 'flex',
             flexDirection: 'column',
@@ -128,7 +128,7 @@ export default function AllTimeStats() {
             style={{
               height: 8,
               borderRadius: 4,
-              background: 'rgba(0,0,0,0.08)',
+              background: 'var(--bg-track)',
               overflow: 'hidden',
               marginBottom: 6,
             }}
@@ -143,7 +143,7 @@ export default function AllTimeStats() {
               }}
             />
           </div>
-          <div style={{ fontSize: 12, color: 'rgba(0,0,0,0.35)' }}>
+          <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
             {progress.current.toLocaleString()} / {progress.required.toLocaleString()} XP to Level {level + 1}
           </div>
         </div>
@@ -175,7 +175,7 @@ export default function AllTimeStats() {
         <section>
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12 }}>
             <Flame size={18} color="#f97316" />
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(0,0,0,0.55)', margin: 0 }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-label)', margin: 0 }}>
               Longest Streaks
             </h2>
           </div>
@@ -187,12 +187,12 @@ export default function AllTimeStats() {
                   display: 'flex',
                   justifyContent: 'space-between',
                   alignItems: 'center',
-                  background: 'rgba(0,0,0,0.03)',
+                  background: 'var(--bg-subtle)',
                   borderRadius: 10,
                   padding: '10px 14px',
                 }}
               >
-                <span style={{ fontSize: 13, color: '#1a1a1a' }}>{s.name}</span>
+                <span style={{ fontSize: 13, color: 'var(--text-primary)' }}>{s.name}</span>
                 <span style={{ fontSize: 14, fontWeight: 700, color: '#f97316' }}>
                   {s.streak} days
                 </span>
@@ -239,7 +239,7 @@ function StatCard({
   return (
     <div
       style={{
-        background: 'rgba(0,0,0,0.03)',
+        background: 'var(--bg-subtle)',
         borderRadius: 14,
         padding: '14px 16px',
         display: 'flex',
@@ -249,7 +249,7 @@ function StatCard({
     >
       {icon}
       <div style={{ flex: 1 }}>
-        <div style={{ fontSize: 11, color: 'rgba(0,0,0,0.35)', marginBottom: 2 }}>{label}</div>
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginBottom: 2 }}>{label}</div>
         <div style={{ fontSize: 18, fontWeight: 700, color }}>{value}</div>
       </div>
     </div>
@@ -260,13 +260,13 @@ function MiniCard({ label, value, color }: { label: string; value: string; color
   return (
     <div
       style={{
-        background: 'rgba(0,0,0,0.03)',
+        background: 'var(--bg-subtle)',
         borderRadius: 10,
         padding: '10px 8px',
         textAlign: 'center',
       }}
     >
-      <div style={{ fontSize: 10, color: 'rgba(0,0,0,0.35)', marginBottom: 2 }}>{label}</div>
+      <div style={{ fontSize: 10, color: 'var(--text-muted)', marginBottom: 2 }}>{label}</div>
       <div style={{ fontSize: 14, fontWeight: 700, color }}>{value}</div>
     </div>
   );

--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -6,12 +6,15 @@ import { usePlayerStore } from '@/stores/player-store';
 import { useHabitStore } from '@/stores/habit-store';
 import { useInventoryStore } from '@/stores/inventory-store';
 import { useGameStore } from '@/stores/game-store';
+import { useThemeStore } from '@/stores/theme-store';
 import { formatDateString, isScheduledForDate } from '@/lib/schedule-utils';
 import { shouldTriggerWeeklyReport, generateAndAwardWeeklyReport } from '@/lib/weekly-report-engine';
 
 export default function AppInitializer() {
   useEffect(() => {
     async function init() {
+      useThemeStore.getState().initialize();
+
       const isFirstUse = (await db.playerProfile.count()) === 0;
 
       await usePlayerStore.getState().initialize();

--- a/src/components/BuildToggle.tsx
+++ b/src/components/BuildToggle.tsx
@@ -24,14 +24,14 @@ export default function BuildToggle() {
         height: 52,
         borderRadius: 12,
         zIndex: 90,
-        background: 'rgba(255, 255, 255, 0.85)',
+        background: 'var(--bg-glass)',
         backdropFilter: 'blur(8px)',
         WebkitBackdropFilter: 'blur(8px)',
-        border: '1px solid rgba(0, 0, 0, 0.08)',
+        border: '1px solid var(--border)',
       }}
       aria-label={isBuild ? 'View mode' : 'Build mode'}
     >
-      <Icon size={22} color={isBuild ? '#d97706' : '#444'} />
+      <Icon size={22} color={isBuild ? 'var(--icon-build)' : 'var(--icon-fab)'} />
     </button>
   );
 }

--- a/src/components/BuildToggle.tsx
+++ b/src/components/BuildToggle.tsx
@@ -24,14 +24,14 @@ export default function BuildToggle() {
         height: 52,
         borderRadius: 12,
         zIndex: 90,
-        background: isBuild ? 'rgba(245, 158, 11, 0.15)' : 'rgba(0, 0, 0, 0.6)',
+        background: 'rgba(255, 255, 255, 0.85)',
         backdropFilter: 'blur(8px)',
         WebkitBackdropFilter: 'blur(8px)',
-        border: isBuild ? '1.5px solid rgba(245, 158, 11, 0.4)' : '1px solid rgba(255,255,255,0.1)',
+        border: '1px solid rgba(0, 0, 0, 0.08)',
       }}
       aria-label={isBuild ? 'View mode' : 'Build mode'}
     >
-      <Icon size={22} color={isBuild ? '#fbbf24' : 'white'} />
+      <Icon size={22} color={isBuild ? '#d97706' : '#444'} />
     </button>
   );
 }

--- a/src/components/BuildToolbar.tsx
+++ b/src/components/BuildToolbar.tsx
@@ -140,7 +140,7 @@ function AssetThumbnail({
         style={{
           fontSize: 9,
           lineHeight: '11px',
-          color: 'rgba(0, 0, 0, 0.55)',
+          color: 'var(--text-label)',
           width: '100%',
           pointerEvents: 'none',
           overflow: 'hidden',
@@ -270,7 +270,7 @@ function InventoryThumbnail({
         style={{
           fontSize: 9,
           lineHeight: '11px',
-          color: 'rgba(0, 0, 0, 0.55)',
+          color: 'var(--text-label)',
           width: '100%',
           pointerEvents: 'none',
           overflow: 'hidden',
@@ -324,12 +324,12 @@ function RoadDeleteButton({ active }: { active: boolean }) {
         flexShrink: 0,
       }}
     >
-      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke={active ? '#DC2626' : '#666'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke={active ? '#DC2626' : 'var(--text-secondary)'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
         <line x1="4" y1="4" x2="20" y2="20" />
         <line x1="20" y1="4" x2="4" y2="20" />
         <rect x="1" y="1" width="22" height="22" rx="3" />
       </svg>
-      <span style={{ fontSize: 9, lineHeight: '11px', color: active ? '#DC2626' : 'rgba(0,0,0,0.55)' }}>
+      <span style={{ fontSize: 9, lineHeight: '11px', color: active ? '#DC2626' : 'var(--text-label)' }}>
         Delete
       </span>
     </button>
@@ -346,7 +346,7 @@ function HouseColorStrip({ ownedColors }: { ownedColors: OwnedColorEntry[] }) {
         gap: 8,
         padding: '6px 12px',
         justifyContent: 'center',
-        borderBottom: '1px solid rgba(0, 0, 0, 0.04)',
+        borderBottom: '1px solid var(--border-subtle)',
       }}
     >
       {ownedColors.map(({ color: c, quantity }) => (
@@ -541,10 +541,10 @@ export default function BuildToolbar() {
         left: 0,
         right: 0,
         zIndex: 100,
-        background: 'rgba(255, 255, 255, 0.88)',
+        background: 'var(--bg-glass)',
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',
-        borderTop: '1px solid rgba(0, 0, 0, 0.08)',
+        borderTop: '1px solid var(--border)',
         paddingBottom: 'env(safe-area-inset-bottom)',
         maxHeight: '25vh',
         display: 'flex',
@@ -587,7 +587,7 @@ export default function BuildToolbar() {
           }}
         >
           <span className="category-spinner" />
-          <span style={{ fontSize: 12, color: 'rgba(0, 0, 0, 0.45)' }}>Loading...</span>
+          <span style={{ fontSize: 12, color: 'var(--text-icon)' }}>Loading...</span>
         </div>
       )}
 
@@ -647,7 +647,7 @@ export default function BuildToolbar() {
             justifyContent: 'center',
             padding: '14px 8px',
             fontSize: 12,
-            color: 'rgba(0, 0, 0, 0.4)',
+            color: 'var(--text-icon)',
           }}
         >
           No items owned. Visit the Shop to buy assets!
@@ -658,7 +658,7 @@ export default function BuildToolbar() {
       <div
         style={{
           display: 'flex',
-          borderTop: '1px solid rgba(0, 0, 0, 0.06)',
+          borderTop: '1px solid var(--border-subtle)',
         }}
       >
         {(Object.keys(CATEGORY_LABELS) as BuildCategory[]).map((cat) => (
@@ -685,7 +685,7 @@ export default function BuildToolbar() {
               color:
                 selectedCategory === cat
                   ? '#6D28D9'
-                  : 'rgba(0, 0, 0, 0.45)',
+                  : 'var(--text-icon)',
               fontSize: 12,
               fontWeight: selectedCategory === cat ? 600 : 400,
               cursor: 'pointer',
@@ -705,7 +705,7 @@ export default function BuildToolbar() {
               padding: '8px 12px',
               border: 'none',
               background: 'transparent',
-              color: 'rgba(0, 0, 0, 0.4)',
+              color: 'var(--text-icon)',
               fontSize: 16,
               cursor: 'pointer',
             }}

--- a/src/components/BuildingPopup.tsx
+++ b/src/components/BuildingPopup.tsx
@@ -46,7 +46,7 @@ export default function BuildingPopup() {
           onClick={moveSelectedBuilding}
           style={{
             ...btnBase,
-            background: 'rgba(255,255,255,0.92)',
+            background: 'var(--bg-sheet)',
           }}
           title="Move"
         >

--- a/src/components/CheckInScreen.tsx
+++ b/src/components/CheckInScreen.tsx
@@ -74,23 +74,23 @@ export default function CheckInScreen() {
   return (
     <>
       <div
-        className="fixed inset-0 bg-gray-950 flex flex-col"
-        style={{ zIndex: 250 }}
+        className="fixed inset-0 flex flex-col"
+        style={{ zIndex: 250, background: 'rgba(245, 245, 250, 0.97)' }}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 pb-1" style={{ paddingTop: 'max(1rem, env(safe-area-inset-top))' }}>
-          <h1 className="text-lg font-bold text-white">Check-In</h1>
+          <h1 className="text-lg font-bold" style={{ color: '#1a1a1a' }}>Check-In</h1>
           <div className="flex items-center gap-1">
             <button
               onClick={() => setShowHabitList(true)}
-              className="p-2 text-gray-400 active:text-white"
+              className="p-2" style={{ color: 'rgba(0,0,0,0.35)' }}
               aria-label="Manage habits"
             >
               <Settings size={20} />
             </button>
             <button
               onClick={handleClose}
-              className="p-2 text-gray-400 active:text-white"
+              className="p-2" style={{ color: 'rgba(0,0,0,0.35)' }}
               aria-label="Close check-in"
             >
               <X size={20} />
@@ -99,13 +99,13 @@ export default function CheckInScreen() {
         </div>
 
         {/* Tab toggle */}
-        <div className="flex mx-4 mb-1 rounded-lg bg-gray-800/50 p-1">
+        <div className="flex mx-4 mb-1 rounded-lg p-1" style={{ background: 'rgba(0,0,0,0.06)' }}>
           <button
             onClick={() => setActiveTab('daily')}
             className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${
               activeTab === 'daily'
                 ? 'bg-violet-600 text-white'
-                : 'text-gray-400'
+                : 'text-[#666]'
             }`}
           >
             Daily
@@ -115,7 +115,7 @@ export default function CheckInScreen() {
             className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${
               activeTab === 'weekly'
                 ? 'bg-violet-600 text-white'
-                : 'text-gray-400'
+                : 'text-[#666]'
             }`}
           >
             Weekly

--- a/src/components/CheckInScreen.tsx
+++ b/src/components/CheckInScreen.tsx
@@ -75,22 +75,22 @@ export default function CheckInScreen() {
     <>
       <div
         className="fixed inset-0 flex flex-col"
-        style={{ zIndex: 250, background: 'rgba(245, 245, 250, 0.97)' }}
+        style={{ zIndex: 250, background: 'var(--bg-page)' }}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 pb-1" style={{ paddingTop: 'max(1rem, env(safe-area-inset-top))' }}>
-          <h1 className="text-lg font-bold" style={{ color: '#1a1a1a' }}>Check-In</h1>
+          <h1 className="text-lg font-bold" style={{ color: 'var(--text-primary)' }}>Check-In</h1>
           <div className="flex items-center gap-1">
             <button
               onClick={() => setShowHabitList(true)}
-              className="p-2" style={{ color: 'rgba(0,0,0,0.35)' }}
+              className="p-2" style={{ color: 'var(--text-muted)' }}
               aria-label="Manage habits"
             >
               <Settings size={20} />
             </button>
             <button
               onClick={handleClose}
-              className="p-2" style={{ color: 'rgba(0,0,0,0.35)' }}
+              className="p-2" style={{ color: 'var(--text-muted)' }}
               aria-label="Close check-in"
             >
               <X size={20} />
@@ -99,7 +99,7 @@ export default function CheckInScreen() {
         </div>
 
         {/* Tab toggle */}
-        <div className="flex mx-4 mb-1 rounded-lg p-1" style={{ background: 'rgba(0,0,0,0.06)' }}>
+        <div className="flex mx-4 mb-1 rounded-lg p-1" style={{ background: 'var(--bg-muted)' }}>
           <button
             onClick={() => setActiveTab('daily')}
             className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${

--- a/src/components/CheckInScreen.tsx
+++ b/src/components/CheckInScreen.tsx
@@ -105,7 +105,7 @@ export default function CheckInScreen() {
             className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${
               activeTab === 'daily'
                 ? 'bg-violet-600 text-white'
-                : 'text-[#666]'
+                : 'text-[var(--text-secondary)]'
             }`}
           >
             Daily
@@ -115,7 +115,7 @@ export default function CheckInScreen() {
             className={`flex-1 py-1.5 rounded-md text-sm font-medium transition-colors ${
               activeTab === 'weekly'
                 ? 'bg-violet-600 text-white'
-                : 'text-[#666]'
+                : 'text-[var(--text-secondary)]'
             }`}
           >
             Weekly

--- a/src/components/CircularProgress.tsx
+++ b/src/components/CircularProgress.tsx
@@ -29,7 +29,7 @@ export default function CircularProgress({
           cy={size / 2}
           r={radius}
           fill="none"
-          stroke="rgba(0,0,0,0.08)"
+          stroke="var(--bg-track)"
           strokeWidth={strokeWidth}
         />
         {/* Progress arc */}
@@ -57,10 +57,10 @@ export default function CircularProgress({
           flexDirection: 'column',
         }}
       >
-        <span style={{ fontSize: size * 0.28, fontWeight: 800, color: '#1a1a1a', lineHeight: 1 }}>
+        <span style={{ fontSize: size * 0.28, fontWeight: 800, color: 'var(--text-primary)', lineHeight: 1 }}>
           {percentage}%
         </span>
-        <span style={{ fontSize: size * 0.1, color: 'rgba(0,0,0,0.35)', marginTop: 2 }}>
+        <span style={{ fontSize: size * 0.1, color: 'var(--text-muted)', marginTop: 2 }}>
           completed
         </span>
       </div>

--- a/src/components/CircularProgress.tsx
+++ b/src/components/CircularProgress.tsx
@@ -29,7 +29,7 @@ export default function CircularProgress({
           cy={size / 2}
           r={radius}
           fill="none"
-          stroke="rgba(255,255,255,0.1)"
+          stroke="rgba(0,0,0,0.08)"
           strokeWidth={strokeWidth}
         />
         {/* Progress arc */}
@@ -57,10 +57,10 @@ export default function CircularProgress({
           flexDirection: 'column',
         }}
       >
-        <span style={{ fontSize: size * 0.28, fontWeight: 800, color: 'white', lineHeight: 1 }}>
+        <span style={{ fontSize: size * 0.28, fontWeight: 800, color: '#1a1a1a', lineHeight: 1 }}>
           {percentage}%
         </span>
-        <span style={{ fontSize: size * 0.1, color: 'rgba(255,255,255,0.5)', marginTop: 2 }}>
+        <span style={{ fontSize: size * 0.1, color: 'rgba(0,0,0,0.35)', marginTop: 2 }}>
           completed
         </span>
       </div>

--- a/src/components/DailyView.tsx
+++ b/src/components/DailyView.tsx
@@ -162,8 +162,8 @@ function RewardFloat({
       <div className="flex flex-col items-center gap-2">
         {isSurpriseBonus && (
           <motion.span
-            className="text-amber-300 font-black text-base tracking-widest uppercase"
-            style={{ textShadow: '0 0 20px rgba(251, 191, 36, 0.6), 0 0 40px rgba(251, 191, 36, 0.3)' }}
+            className="text-amber-600 font-black text-base tracking-widest uppercase"
+            style={{ textShadow: '0 0 20px rgba(251, 191, 36, 0.3)' }}
             initial={{ opacity: 0, y: -10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.15, duration: 0.3 }}
@@ -183,17 +183,17 @@ function RewardFloat({
           }
         >
           <div className="flex items-center gap-1.5">
-            <Sparkles size={22} className="text-emerald-400" />
+            <Sparkles size={22} className="text-emerald-500" />
             <span
-              className="text-emerald-300 font-extrabold text-2xl"
-              style={{ textShadow: '0 0 16px rgba(16,185,129,0.5), 0 2px 4px rgba(0,0,0,0.3)' }}
+              className="text-emerald-600 font-extrabold text-2xl"
+              style={{ textShadow: '0 0 16px rgba(16,185,129,0.3)' }}
             >
               +{xp} XP
             </span>
           </div>
           <span
-            className="text-yellow-300 font-extrabold text-2xl"
-            style={{ textShadow: '0 0 16px rgba(252,211,77,0.5), 0 2px 4px rgba(0,0,0,0.3)', display: 'inline-flex', alignItems: 'center', gap: 4 }}
+            className="text-yellow-600 font-extrabold text-2xl"
+            style={{ textShadow: '0 0 16px rgba(252,211,77,0.3)', display: 'inline-flex', alignItems: 'center', gap: 4 }}
           >
             +{coins} <img src="/assets/coin/coin.svg" alt="coin" style={{ width: 28, height: 28 }} />
           </span>
@@ -235,10 +235,10 @@ function DateStrip({
               isSelected
                 ? 'bg-violet-600 text-white'
                 : isToday
-                  ? 'bg-violet-600/20 text-violet-300'
+                  ? 'bg-violet-600/15 text-violet-700'
                   : isFuture
-                    ? 'opacity-30 pointer-events-none text-gray-500'
-                    : 'text-gray-400 active:bg-gray-700'
+                    ? 'opacity-30 pointer-events-none text-[rgba(0,0,0,0.35)]'
+                    : 'text-[#666] active:bg-[rgba(0,0,0,0.05)]'
             }`}
           >
             <span className="text-[10px]">{DAY_LABELS[i]}</span>
@@ -312,17 +312,17 @@ function SwipeCard({
       onDragEnd={handleDragEnd}
       className="absolute inset-0 touch-none"
     >
-      <div className="h-full rounded-2xl bg-gray-800 border border-gray-700 px-6 py-8 flex flex-col items-center justify-center relative overflow-hidden select-none">
+      <div className="h-full rounded-2xl px-6 py-8 flex flex-col items-center justify-center relative overflow-hidden select-none" style={{ background: 'rgba(255,255,255,0.8)', border: '1px solid rgba(0,0,0,0.06)', boxShadow: '0 2px 16px rgba(0,0,0,0.06)' }}>
         {/* Swipe indicators */}
         <motion.div
           style={{ opacity: doneOpacity }}
-          className="absolute top-4 left-4 px-3 py-1 rounded-full bg-emerald-500/20 border-2 border-emerald-500 text-emerald-400 text-sm font-bold"
+          className="absolute top-4 left-4 px-3 py-1 rounded-full bg-emerald-100 border-2 border-emerald-500 text-emerald-700 text-sm font-bold"
         >
           DONE
         </motion.div>
         <motion.div
           style={{ opacity: skipOpacity }}
-          className="absolute top-4 right-4 px-3 py-1 rounded-full bg-gray-500/20 border-2 border-gray-500 text-gray-400 text-sm font-bold"
+          className="absolute top-4 right-4 px-3 py-1 rounded-full bg-gray-200 border-2 border-gray-400 text-gray-600 text-sm font-bold"
         >
           SKIP
         </motion.div>
@@ -344,16 +344,16 @@ function SwipeCard({
         </span>
 
         {/* Habit name */}
-        <h3 className="text-xl font-bold text-white text-center mb-4">{card.habit.name}</h3>
+        <h3 className="text-xl font-bold text-center mb-4" style={{ color: '#1a1a1a' }}>{card.habit.name}</h3>
 
         {/* Monthly progress */}
-        <p className="text-sm text-gray-400 mb-2">
+        <p className="text-sm mb-2" style={{ color: '#666' }}>
           {card.monthProgress.done}/{card.monthProgress.total} this month
         </p>
 
         {/* Streak */}
         {card.streak > 0 && (
-          <div className="flex items-center gap-1 text-orange-400">
+          <div className="flex items-center gap-1 text-orange-500">
             <Flame size={16} />
             <span className="text-sm font-semibold">{card.streak} day streak</span>
           </div>
@@ -381,27 +381,27 @@ function SessionSummary({
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
       {perfectDay && (
-        <div className="flex items-center gap-2 mb-4 text-yellow-400">
+        <div className="flex items-center gap-2 mb-4 text-yellow-600">
           <Trophy size={24} />
           <span className="text-lg font-bold">Perfect check-in!</span>
           <Trophy size={24} />
         </div>
       )}
 
-      <h2 className="text-2xl font-bold text-white mb-6">Session Complete</h2>
+      <h2 className="text-2xl font-bold mb-6" style={{ color: '#1a1a1a' }}>Session Complete</h2>
 
       <div className="space-y-3 mb-8 w-full max-w-[240px]">
-        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
-          <span className="text-gray-400 text-sm">Habits completed</span>
-          <span className="text-white font-bold">{completed}/{total}</span>
+        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
+          <span className="text-sm" style={{ color: '#666' }}>Habits completed</span>
+          <span className="font-bold" style={{ color: '#1a1a1a' }}>{completed}/{total}</span>
         </div>
-        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
-          <span className="text-gray-400 text-sm">XP earned</span>
-          <span className="text-emerald-400 font-bold">+{xp}</span>
+        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
+          <span className="text-sm" style={{ color: '#666' }}>XP earned</span>
+          <span className="text-emerald-600 font-bold">+{xp}</span>
         </div>
-        <div className="flex justify-between items-center bg-gray-800 rounded-xl px-4 py-3">
-          <span className="text-gray-400 text-sm">Coins earned</span>
-          <span className="text-yellow-400 font-bold">+{coins}</span>
+        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
+          <span className="text-sm" style={{ color: '#666' }}>Coins earned</span>
+          <span className="text-yellow-600 font-bold">+{coins}</span>
         </div>
       </div>
 
@@ -675,20 +675,20 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
 
       {/* Event banners */}
       {doubleXPEventActive && (
-        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-amber-500/20 border border-amber-500/40 text-center">
-          <span className="text-amber-400 font-bold text-sm">&#x26A1; 2x XP Active!</span>
+        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-amber-100 border border-amber-300 text-center">
+          <span className="text-amber-700 font-bold text-sm">&#x26A1; 2x XP Active!</span>
         </div>
       )}
       {firstWeekBoostActive && (
-        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-violet-500/20 border border-violet-500/40 text-center">
-          <span className="text-violet-300 font-bold text-sm">&#x1F680; 2x XP BOOST — First Week!</span>
+        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-violet-100 border border-violet-300 text-center">
+          <span className="text-violet-700 font-bold text-sm">&#x1F680; 2x XP BOOST — First Week!</span>
         </div>
       )}
 
       {/* Card area */}
       {loading ? (
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-gray-500 text-sm">Loading...</div>
+          <div className="text-sm" style={{ color: 'rgba(0,0,0,0.35)' }}>Loading...</div>
         </div>
       ) : showSummary ? (
         <SessionSummary
@@ -702,7 +702,7 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
       ) : (
         <div className="flex-1 flex flex-col px-4 pt-2 pb-2 min-h-0">
           {/* Counter */}
-          <p className="text-xs text-gray-500 mb-2 text-center shrink-0">
+          <p className="text-xs mb-2 text-center shrink-0" style={{ color: 'rgba(0,0,0,0.35)' }}>
             {currentIndex + 1} / {cards.length}
           </p>
 
@@ -711,8 +711,8 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
             {/* Next card (behind) */}
             {currentIndex + 1 < cards.length && (
               <motion.div
-                className="absolute inset-0 rounded-2xl bg-gray-800 border border-gray-700 pointer-events-none overflow-hidden"
-                style={{ scale: backScale, opacity: backOpacity }}
+                className="absolute inset-0 rounded-2xl pointer-events-none overflow-hidden"
+                style={{ background: 'rgba(255,255,255,0.4)', border: '1px solid rgba(0,0,0,0.06)', scale: backScale, opacity: backOpacity }}
               >
                 {(() => {
                   const next = cards[currentIndex + 1];
@@ -726,7 +726,7 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
                       >
                         <NextIcon size={28} color={nextMeta.color} />
                       </div>
-                      <h3 className="text-lg font-bold text-white text-center opacity-60">
+                      <h3 className="text-lg font-bold text-center opacity-40" style={{ color: '#1a1a1a' }}>
                         {next.habit.name}
                       </h3>
                     </div>
@@ -754,7 +754,8 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
             <button
               onClick={handleTapSkip}
               disabled={isAnimating}
-              className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl border border-gray-600 text-gray-400 font-medium active:bg-gray-800 transition-colors disabled:opacity-40"
+              className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl font-medium transition-colors disabled:opacity-40"
+              style={{ border: '1px solid rgba(0,0,0,0.12)', color: '#666' }}
             >
               <ChevronLeft size={18} />
               <span>Skip</span>
@@ -777,12 +778,13 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
       {/* Don't show today checkbox */}
       {selectedDate === todayStr && (
         <div className="px-4 pb-4 pt-1 shrink-0">
-          <label className="flex items-center gap-2 text-xs text-gray-500 cursor-pointer">
+          <label className="flex items-center gap-2 text-xs cursor-pointer" style={{ color: 'rgba(0,0,0,0.35)' }}>
             <input
               type="checkbox"
               checked={dontShowCheckInToday === todayStr}
               onChange={handleDontShowToggle}
-              className="w-3.5 h-3.5 rounded border-gray-600 bg-gray-800 text-violet-600 focus:ring-0 focus:ring-offset-0"
+              className="w-3.5 h-3.5 rounded text-violet-600 focus:ring-0 focus:ring-offset-0"
+              style={{ borderColor: 'rgba(0,0,0,0.15)', background: 'white' }}
             />
             Don&apos;t auto-open today
           </label>

--- a/src/components/DailyView.tsx
+++ b/src/components/DailyView.tsx
@@ -237,8 +237,8 @@ function DateStrip({
                 : isToday
                   ? 'bg-violet-600/15 text-violet-700 dark:bg-violet-600/20 dark:text-violet-300'
                   : isFuture
-                    ? 'opacity-30 pointer-events-none text-[rgba(0,0,0,0.35)]'
-                    : 'text-[#666] active:bg-[rgba(0,0,0,0.05)]'
+                    ? 'opacity-30 pointer-events-none text-[var(--text-muted)]'
+                    : 'text-[var(--text-secondary)] active:bg-[rgba(0,0,0,0.05)] dark:active:bg-[rgba(255,255,255,0.05)]'
             }`}
           >
             <span className="text-[10px]">{DAY_LABELS[i]}</span>

--- a/src/components/DailyView.tsx
+++ b/src/components/DailyView.tsx
@@ -185,14 +185,14 @@ function RewardFloat({
           <div className="flex items-center gap-1.5">
             <Sparkles size={22} className="text-emerald-500" />
             <span
-              className="text-emerald-600 font-extrabold text-2xl"
+              className="text-emerald-600 dark:text-emerald-400 font-extrabold text-2xl"
               style={{ textShadow: '0 0 16px rgba(16,185,129,0.3)' }}
             >
               +{xp} XP
             </span>
           </div>
           <span
-            className="text-yellow-600 font-extrabold text-2xl"
+            className="text-yellow-600 dark:text-yellow-400 font-extrabold text-2xl"
             style={{ textShadow: '0 0 16px rgba(252,211,77,0.3)', display: 'inline-flex', alignItems: 'center', gap: 4 }}
           >
             +{coins} <img src="/assets/coin/coin.svg" alt="coin" style={{ width: 28, height: 28 }} />
@@ -235,7 +235,7 @@ function DateStrip({
               isSelected
                 ? 'bg-violet-600 text-white'
                 : isToday
-                  ? 'bg-violet-600/15 text-violet-700'
+                  ? 'bg-violet-600/15 text-violet-700 dark:bg-violet-600/20 dark:text-violet-300'
                   : isFuture
                     ? 'opacity-30 pointer-events-none text-[rgba(0,0,0,0.35)]'
                     : 'text-[#666] active:bg-[rgba(0,0,0,0.05)]'
@@ -312,11 +312,11 @@ function SwipeCard({
       onDragEnd={handleDragEnd}
       className="absolute inset-0 touch-none"
     >
-      <div className="h-full rounded-2xl px-6 py-8 flex flex-col items-center justify-center relative overflow-hidden select-none" style={{ background: 'rgba(255,255,255,0.8)', border: '1px solid rgba(0,0,0,0.06)', boxShadow: '0 2px 16px rgba(0,0,0,0.06)' }}>
+      <div className="h-full rounded-2xl px-6 py-8 flex flex-col items-center justify-center relative overflow-hidden select-none" style={{ background: 'var(--bg-elevated)', border: '1px solid var(--border-subtle)', boxShadow: '0 2px 16px var(--border-subtle)' }}>
         {/* Swipe indicators */}
         <motion.div
           style={{ opacity: doneOpacity }}
-          className="absolute top-4 left-4 px-3 py-1 rounded-full bg-emerald-100 border-2 border-emerald-500 text-emerald-700 text-sm font-bold"
+          className="absolute top-4 left-4 px-3 py-1 rounded-full bg-emerald-100 dark:bg-emerald-500/20 border-2 border-emerald-500 text-emerald-700 dark:text-emerald-400 text-sm font-bold"
         >
           DONE
         </motion.div>
@@ -344,16 +344,16 @@ function SwipeCard({
         </span>
 
         {/* Habit name */}
-        <h3 className="text-xl font-bold text-center mb-4" style={{ color: '#1a1a1a' }}>{card.habit.name}</h3>
+        <h3 className="text-xl font-bold text-center mb-4" style={{ color: 'var(--text-primary)' }}>{card.habit.name}</h3>
 
         {/* Monthly progress */}
-        <p className="text-sm mb-2" style={{ color: '#666' }}>
+        <p className="text-sm mb-2" style={{ color: 'var(--text-secondary)' }}>
           {card.monthProgress.done}/{card.monthProgress.total} this month
         </p>
 
         {/* Streak */}
         {card.streak > 0 && (
-          <div className="flex items-center gap-1 text-orange-500">
+          <div className="flex items-center gap-1 text-orange-500 dark:text-orange-400">
             <Flame size={16} />
             <span className="text-sm font-semibold">{card.streak} day streak</span>
           </div>
@@ -381,27 +381,27 @@ function SessionSummary({
   return (
     <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
       {perfectDay && (
-        <div className="flex items-center gap-2 mb-4 text-yellow-600">
+        <div className="flex items-center gap-2 mb-4 text-yellow-600 dark:text-yellow-400">
           <Trophy size={24} />
           <span className="text-lg font-bold">Perfect check-in!</span>
           <Trophy size={24} />
         </div>
       )}
 
-      <h2 className="text-2xl font-bold mb-6" style={{ color: '#1a1a1a' }}>Session Complete</h2>
+      <h2 className="text-2xl font-bold mb-6" style={{ color: 'var(--text-primary)' }}>Session Complete</h2>
 
       <div className="space-y-3 mb-8 w-full max-w-[240px]">
-        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
-          <span className="text-sm" style={{ color: '#666' }}>Habits completed</span>
-          <span className="font-bold" style={{ color: '#1a1a1a' }}>{completed}/{total}</span>
+        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-subtle)' }}>
+          <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>Habits completed</span>
+          <span className="font-bold" style={{ color: 'var(--text-primary)' }}>{completed}/{total}</span>
         </div>
-        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
-          <span className="text-sm" style={{ color: '#666' }}>XP earned</span>
-          <span className="text-emerald-600 font-bold">+{xp}</span>
+        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-subtle)' }}>
+          <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>XP earned</span>
+          <span className="text-emerald-600 dark:text-emerald-400 font-bold">+{xp}</span>
         </div>
-        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
-          <span className="text-sm" style={{ color: '#666' }}>Coins earned</span>
-          <span className="text-yellow-600 font-bold">+{coins}</span>
+        <div className="flex justify-between items-center rounded-xl px-4 py-3" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-subtle)' }}>
+          <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>Coins earned</span>
+          <span className="text-yellow-600 dark:text-yellow-400 font-bold">+{coins}</span>
         </div>
       </div>
 
@@ -675,20 +675,20 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
 
       {/* Event banners */}
       {doubleXPEventActive && (
-        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-amber-100 border border-amber-300 text-center">
-          <span className="text-amber-700 font-bold text-sm">&#x26A1; 2x XP Active!</span>
+        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-amber-100 dark:bg-amber-500/20 border border-amber-300 dark:border-amber-700/50 text-center">
+          <span className="text-amber-700 dark:text-amber-400 font-bold text-sm">&#x26A1; 2x XP Active!</span>
         </div>
       )}
       {firstWeekBoostActive && (
-        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-violet-100 border border-violet-300 text-center">
-          <span className="text-violet-700 font-bold text-sm">&#x1F680; 2x XP BOOST — First Week!</span>
+        <div className="mx-4 mb-2 py-2 px-3 rounded-lg bg-violet-100 dark:bg-violet-500/20 border border-violet-300 dark:border-violet-500/40 text-center">
+          <span className="text-violet-700 dark:text-violet-300 font-bold text-sm">&#x1F680; 2x XP BOOST — First Week!</span>
         </div>
       )}
 
       {/* Card area */}
       {loading ? (
         <div className="flex-1 flex items-center justify-center">
-          <div className="text-sm" style={{ color: 'rgba(0,0,0,0.35)' }}>Loading...</div>
+          <div className="text-sm" style={{ color: 'var(--text-muted)' }}>Loading...</div>
         </div>
       ) : showSummary ? (
         <SessionSummary
@@ -702,7 +702,7 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
       ) : (
         <div className="flex-1 flex flex-col px-4 pt-2 pb-2 min-h-0">
           {/* Counter */}
-          <p className="text-xs mb-2 text-center shrink-0" style={{ color: 'rgba(0,0,0,0.35)' }}>
+          <p className="text-xs mb-2 text-center shrink-0" style={{ color: 'var(--text-muted)' }}>
             {currentIndex + 1} / {cards.length}
           </p>
 
@@ -712,7 +712,7 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
             {currentIndex + 1 < cards.length && (
               <motion.div
                 className="absolute inset-0 rounded-2xl pointer-events-none overflow-hidden"
-                style={{ background: 'rgba(255,255,255,0.4)', border: '1px solid rgba(0,0,0,0.06)', scale: backScale, opacity: backOpacity }}
+                style={{ background: 'var(--bg-back-card)', border: '1px solid var(--border-subtle)', scale: backScale, opacity: backOpacity }}
               >
                 {(() => {
                   const next = cards[currentIndex + 1];
@@ -726,7 +726,7 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
                       >
                         <NextIcon size={28} color={nextMeta.color} />
                       </div>
-                      <h3 className="text-lg font-bold text-center opacity-40" style={{ color: '#1a1a1a' }}>
+                      <h3 className="text-lg font-bold text-center opacity-40" style={{ color: 'var(--text-primary)' }}>
                         {next.habit.name}
                       </h3>
                     </div>
@@ -755,7 +755,7 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
               onClick={handleTapSkip}
               disabled={isAnimating}
               className="flex-1 flex items-center justify-center gap-2 py-3 rounded-xl font-medium transition-colors disabled:opacity-40"
-              style={{ border: '1px solid rgba(0,0,0,0.12)', color: '#666' }}
+              style={{ border: '1px solid var(--border-strong)', color: 'var(--text-secondary)' }}
             >
               <ChevronLeft size={18} />
               <span>Skip</span>
@@ -778,13 +778,13 @@ export default function DailyView({ weekDates, todayStr, selectedDate, onSelectD
       {/* Don't show today checkbox */}
       {selectedDate === todayStr && (
         <div className="px-4 pb-4 pt-1 shrink-0">
-          <label className="flex items-center gap-2 text-xs cursor-pointer" style={{ color: 'rgba(0,0,0,0.35)' }}>
+          <label className="flex items-center gap-2 text-xs cursor-pointer" style={{ color: 'var(--text-muted)' }}>
             <input
               type="checkbox"
               checked={dontShowCheckInToday === todayStr}
               onChange={handleDontShowToggle}
               className="w-3.5 h-3.5 rounded text-violet-600 focus:ring-0 focus:ring-offset-0"
-              style={{ borderColor: 'rgba(0,0,0,0.15)', background: 'white' }}
+              style={{ borderColor: 'var(--border-handle)', background: 'white' }}
             />
             Don&apos;t auto-open today
           </label>

--- a/src/components/HabitFab.tsx
+++ b/src/components/HabitFab.tsx
@@ -30,17 +30,21 @@ export default function HabitFab() {
   return (
     <button
       onClick={() => openScreen('check-in')}
-      className="fixed bottom-6 right-4 flex items-center justify-center shadow-lg active:scale-95 transition-transform bg-emerald-500 text-white"
+      className="fixed bottom-6 right-4 flex items-center justify-center shadow-lg active:scale-95 transition-transform"
       style={{
         width: 52,
         height: 52,
         borderRadius: 12,
         zIndex: 90,
         position: 'fixed',
+        background: 'rgba(255, 255, 255, 0.85)',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
+        border: '1px solid rgba(0, 0, 0, 0.08)',
       }}
       aria-label="Check in habits"
     >
-      <Check size={24} strokeWidth={3} />
+      <Check size={24} strokeWidth={3} color="#444" />
 
       {/* Pending badge */}
       {pendingCount > 0 && (

--- a/src/components/HabitFab.tsx
+++ b/src/components/HabitFab.tsx
@@ -37,14 +37,14 @@ export default function HabitFab() {
         borderRadius: 12,
         zIndex: 90,
         position: 'fixed',
-        background: 'rgba(255, 255, 255, 0.85)',
+        background: 'var(--bg-glass)',
         backdropFilter: 'blur(8px)',
         WebkitBackdropFilter: 'blur(8px)',
-        border: '1px solid rgba(0, 0, 0, 0.08)',
+        border: '1px solid var(--border)',
       }}
       aria-label="Check in habits"
     >
-      <Check size={24} strokeWidth={3} color="#444" />
+      <Check size={24} strokeWidth={3} color="var(--icon-fab)" />
 
       {/* Pending badge */}
       {pendingCount > 0 && (

--- a/src/components/HabitForm.tsx
+++ b/src/components/HabitForm.tsx
@@ -108,14 +108,14 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
   return (
     <div
       className="fixed inset-0 flex flex-col"
-      style={{ zIndex: 310, background: 'rgba(245, 245, 250, 0.97)' }}
+      style={{ zIndex: 310, background: 'var(--bg-page)' }}
     >
       {/* Header */}
       <div className="flex items-center gap-3 px-4 pt-[max(env(safe-area-inset-top),12px)] pb-3">
-        <button onClick={onClose} className="p-1 -ml-1" style={{ color: 'rgba(0,0,0,0.35)' }}>
+        <button onClick={onClose} className="p-1 -ml-1" style={{ color: 'var(--text-muted)' }}>
           <ChevronLeft size={24} />
         </button>
-        <h2 className="text-lg font-semibold" style={{ color: '#1a1a1a' }}>
+        <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>
           {mode === 'edit' ? 'Edit Habit' : mode === 'onboarding' ? 'New Habit' : 'Create Habit'}
         </h2>
       </div>
@@ -124,21 +124,21 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
       <div className="flex-1 overflow-y-auto px-4 pb-6 space-y-6">
         {/* Name */}
         <div>
-          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Name</label>
+          <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>Name</label>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g., Go to the gym"
             className="w-full rounded-xl px-4 py-3 text-base outline-none focus:ring-2 focus:ring-violet-500"
-            style={{ background: 'rgba(255,255,255,0.6)', color: '#1a1a1a', border: '1px solid rgba(0,0,0,0.08)' }}
+            style={{ background: 'var(--bg-card)', color: 'var(--text-primary)', border: '1px solid var(--border)' }}
             autoFocus={mode !== 'edit'}
           />
         </div>
 
         {/* Category */}
         <div>
-          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Category</label>
+          <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>Category</label>
           <div className="grid grid-cols-4 gap-2">
             {categories.map((cat) => {
               const meta = CATEGORY_META[cat];
@@ -150,12 +150,12 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                   onClick={() => setCategory(cat)}
                   className="flex flex-col items-center gap-1 rounded-xl py-2.5 px-1 transition-colors"
                   style={{
-                    background: selected ? meta.color + '22' : 'rgba(255,255,255,0.6)',
+                    background: selected ? meta.color + '22' : 'var(--bg-card)',
                     border: selected ? `2px solid ${meta.color}` : '2px solid transparent',
                   }}
                 >
-                  <Icon size={20} color={selected ? meta.color : 'rgba(0,0,0,0.45)'} />
-                  <span className="text-xs" style={{ color: selected ? meta.color : 'rgba(0,0,0,0.45)' }}>
+                  <Icon size={20} color={selected ? meta.color : 'var(--text-icon)'} />
+                  <span className="text-xs" style={{ color: selected ? meta.color : 'var(--text-icon)' }}>
                     {cat}
                   </span>
                 </button>
@@ -166,7 +166,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Frequency */}
         <div>
-          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Frequency</label>
+          <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>Frequency</label>
           <div className="flex flex-wrap gap-2">
             {(GAME_CONFIG.habits.frequency_options as HabitFrequencyType[]).map((ft) => (
               <button
@@ -174,8 +174,8 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                 onClick={() => setFreqType(ft)}
                 className="rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors"
                 style={{
-                  background: freqType === ft ? selectedColor + '22' : 'rgba(255,255,255,0.6)',
-                  color: freqType === ft ? selectedColor : 'rgba(0,0,0,0.45)',
+                  background: freqType === ft ? selectedColor + '22' : 'var(--bg-card)',
+                  color: freqType === ft ? selectedColor : 'var(--text-icon)',
                   border: freqType === ft ? `1.5px solid ${selectedColor}` : '1.5px solid transparent',
                 }}
               >
@@ -186,19 +186,19 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
           {/* Times per week stepper */}
           {freqType === 'times_per_week' && (
-            <div className="flex items-center gap-4 mt-3 rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
-              <span className="text-sm" style={{ color: '#1a1a1a' }}>Times per week</span>
+            <div className="flex items-center gap-4 mt-3 rounded-xl px-4 py-3" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-subtle)' }}>
+              <span className="text-sm" style={{ color: 'var(--text-primary)' }}>Times per week</span>
               <div className="flex items-center gap-3 ml-auto">
                 <button
                   onClick={() => setTimesPerWeek(Math.max(1, timesPerWeek - 1))}
-                  className="w-8 h-8 rounded-full flex items-center justify-center text-lg" style={{ background: 'rgba(0,0,0,0.06)', color: '#1a1a1a' }}
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-lg" style={{ background: 'var(--bg-muted)', color: 'var(--text-primary)' }}
                 >
                   -
                 </button>
-                <span className="font-semibold w-4 text-center" style={{ color: '#1a1a1a' }}>{timesPerWeek}</span>
+                <span className="font-semibold w-4 text-center" style={{ color: 'var(--text-primary)' }}>{timesPerWeek}</span>
                 <button
                   onClick={() => setTimesPerWeek(Math.min(7, timesPerWeek + 1))}
-                  className="w-8 h-8 rounded-full flex items-center justify-center text-lg" style={{ background: 'rgba(0,0,0,0.06)', color: '#1a1a1a' }}
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-lg" style={{ background: 'var(--bg-muted)', color: 'var(--text-primary)' }}
                 >
                   +
                 </button>
@@ -215,8 +215,8 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                   onClick={() => toggleDay(i)}
                   className="flex-1 py-2 rounded-lg text-xs font-medium transition-colors"
                   style={{
-                    background: specificDays.includes(i) ? selectedColor + '22' : 'rgba(255,255,255,0.6)',
-                    color: specificDays.includes(i) ? selectedColor : 'rgba(0,0,0,0.45)',
+                    background: specificDays.includes(i) ? selectedColor + '22' : 'var(--bg-card)',
+                    color: specificDays.includes(i) ? selectedColor : 'var(--text-icon)',
                     border: specificDays.includes(i) ? `1.5px solid ${selectedColor}` : '1.5px solid transparent',
                   }}
                 >
@@ -229,7 +229,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Difficulty */}
         <div>
-          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Difficulty</label>
+          <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>Difficulty</label>
           <div className="space-y-2">
             {difficulties.map((tier) => {
               const selected = difficulty === tier.id;
@@ -241,17 +241,17 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                   onClick={() => setDifficulty(tier.id as HabitDifficulty)}
                   className="w-full text-left rounded-xl px-4 py-3 transition-colors"
                   style={{
-                    background: selected ? selectedColor + '15' : 'rgba(255,255,255,0.6)',
+                    background: selected ? selectedColor + '15' : 'var(--bg-card)',
                     border: selected ? `2px solid ${selectedColor}` : '2px solid transparent',
                   }}
                 >
                   <div className="flex items-center justify-between">
-                    <span className="font-semibold" style={{ color: '#1a1a1a' }}>{tier.label}</span>
-                    <span className="text-xs" style={{ color: '#666' }}>
+                    <span className="font-semibold" style={{ color: 'var(--text-primary)' }}>{tier.label}</span>
+                    <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
                       +{xp} XP &middot; +{coins} coins
                     </span>
                   </div>
-                  <p className="text-xs mt-0.5" style={{ color: '#666' }}>{tier.description}</p>
+                  <p className="text-xs mt-0.5" style={{ color: 'var(--text-secondary)' }}>{tier.description}</p>
                 </button>
               );
             })}
@@ -260,7 +260,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Time of Day */}
         <div>
-          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Time of Day</label>
+          <label className="block text-sm mb-1.5" style={{ color: 'var(--text-secondary)' }}>Time of Day</label>
           <div className="flex gap-2">
             {TIME_OPTIONS.map((opt) => (
               <button
@@ -268,8 +268,8 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                 onClick={() => setTimeOfDay(opt.value)}
                 className="flex-1 rounded-xl py-2.5 text-sm font-medium transition-colors"
                 style={{
-                  background: timeOfDay === opt.value ? selectedColor + '22' : 'rgba(255,255,255,0.6)',
-                  color: timeOfDay === opt.value ? selectedColor : 'rgba(0,0,0,0.45)',
+                  background: timeOfDay === opt.value ? selectedColor + '22' : 'var(--bg-card)',
+                  color: timeOfDay === opt.value ? selectedColor : 'var(--text-icon)',
                   border: timeOfDay === opt.value ? `1.5px solid ${selectedColor}` : '1.5px solid transparent',
                 }}
               >
@@ -281,7 +281,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Start/End Dates */}
         <div>
-          <label className="flex items-center gap-2 text-sm cursor-pointer" style={{ color: '#666' }}>
+          <label className="flex items-center gap-2 text-sm cursor-pointer" style={{ color: 'var(--text-secondary)' }}>
             <input
               type="checkbox"
               checked={showDates}
@@ -293,31 +293,31 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
           {showDates && (
             <div className="grid grid-cols-2 gap-3 mt-2">
               <div>
-                <span className="text-xs" style={{ color: 'rgba(0,0,0,0.35)' }}>Start</span>
+                <span className="text-xs" style={{ color: 'var(--text-muted)' }}>Start</span>
                 <input
                   type="date"
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
                   className="w-full rounded-lg px-3 py-2 text-sm outline-none mt-1"
-                  style={{ background: 'rgba(255,255,255,0.6)', color: '#1a1a1a', border: '1px solid rgba(0,0,0,0.08)' }}
+                  style={{ background: 'var(--bg-card)', color: 'var(--text-primary)', border: '1px solid var(--border)' }}
                 />
               </div>
               <div>
-                <span className="text-xs" style={{ color: 'rgba(0,0,0,0.35)' }}>End (optional)</span>
+                <span className="text-xs" style={{ color: 'var(--text-muted)' }}>End (optional)</span>
                 <div className="relative mt-1">
                   <input
                     type="date"
                     value={endDate}
                     onChange={(e) => setEndDate(e.target.value)}
                     className="w-full rounded-lg px-3 py-2 text-sm outline-none"
-                    style={{ background: 'rgba(255,255,255,0.6)', color: '#1a1a1a', border: '1px solid rgba(0,0,0,0.08)' }}
+                    style={{ background: 'var(--bg-card)', color: 'var(--text-primary)', border: '1px solid var(--border)' }}
                   />
                   {endDate && (
                     <button
                       type="button"
                       onClick={() => setEndDate('')}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-lg leading-none"
-                      style={{ color: 'rgba(0,0,0,0.35)' }}
+                      style={{ color: 'var(--text-muted)' }}
                       aria-label="Clear end date"
                     >
                       &times;
@@ -333,7 +333,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
         {mode === 'edit' && (
           <button
             onClick={() => setShowArchiveConfirm(true)}
-            className="text-sm text-red-600 underline underline-offset-2"
+            className="text-sm text-red-600 dark:text-red-400 underline underline-offset-2"
           >
             Archive this habit
           </button>
@@ -341,7 +341,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
       </div>
 
       {/* Save button */}
-      <div className="px-4 pb-[max(env(safe-area-inset-bottom),12px)] pt-3" style={{ borderTop: '1px solid rgba(0,0,0,0.06)' }}>
+      <div className="px-4 pb-[max(env(safe-area-inset-bottom),12px)] pt-3" style={{ borderTop: '1px solid var(--border-subtle)' }}>
         <button
           onClick={handleSave}
           disabled={!name.trim()}
@@ -361,17 +361,17 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
         >
           <div
             className="rounded-2xl p-5 w-full max-w-xs"
-            style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
+            style={{ background: 'var(--bg-sheet)', border: '1px solid var(--border)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="font-semibold text-base mb-2" style={{ color: '#1a1a1a' }}>Archive habit?</h3>
-            <p className="text-sm mb-4" style={{ color: '#666' }}>
-              <strong style={{ color: '#1a1a1a' }}>{habit?.name}</strong> won&apos;t appear in check-ins anymore. Historical data is kept.
+            <h3 className="font-semibold text-base mb-2" style={{ color: 'var(--text-primary)' }}>Archive habit?</h3>
+            <p className="text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
+              <strong style={{ color: 'var(--text-primary)' }}>{habit?.name}</strong> won&apos;t appear in check-ins anymore. Historical data is kept.
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setShowArchiveConfirm(false)}
-                className="flex-1 py-2.5 rounded-xl text-sm" style={{ background: 'transparent', border: '1px solid rgba(0,0,0,0.12)', color: '#666' }}
+                className="flex-1 py-2.5 rounded-xl text-sm" style={{ background: 'transparent', border: '1px solid var(--border-strong)', color: 'var(--text-secondary)' }}
               >
                 Cancel
               </button>

--- a/src/components/HabitForm.tsx
+++ b/src/components/HabitForm.tsx
@@ -107,15 +107,15 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
   return (
     <div
-      className="fixed inset-0 flex flex-col bg-gray-900"
-      style={{ zIndex: 310 }}
+      className="fixed inset-0 flex flex-col"
+      style={{ zIndex: 310, background: 'rgba(245, 245, 250, 0.97)' }}
     >
       {/* Header */}
       <div className="flex items-center gap-3 px-4 pt-[max(env(safe-area-inset-top),12px)] pb-3">
-        <button onClick={onClose} className="p-1 -ml-1 text-gray-400 active:text-white">
+        <button onClick={onClose} className="p-1 -ml-1" style={{ color: 'rgba(0,0,0,0.35)' }}>
           <ChevronLeft size={24} />
         </button>
-        <h2 className="text-lg font-semibold text-white">
+        <h2 className="text-lg font-semibold" style={{ color: '#1a1a1a' }}>
           {mode === 'edit' ? 'Edit Habit' : mode === 'onboarding' ? 'New Habit' : 'Create Habit'}
         </h2>
       </div>
@@ -124,20 +124,21 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
       <div className="flex-1 overflow-y-auto px-4 pb-6 space-y-6">
         {/* Name */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1.5">Name</label>
+          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Name</label>
           <input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g., Go to the gym"
-            className="w-full bg-gray-800 text-white rounded-xl px-4 py-3 text-base outline-none focus:ring-2 focus:ring-violet-500 placeholder:text-gray-500"
+            className="w-full rounded-xl px-4 py-3 text-base outline-none focus:ring-2 focus:ring-violet-500"
+            style={{ background: 'rgba(255,255,255,0.6)', color: '#1a1a1a', border: '1px solid rgba(0,0,0,0.08)' }}
             autoFocus={mode !== 'edit'}
           />
         </div>
 
         {/* Category */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1.5">Category</label>
+          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Category</label>
           <div className="grid grid-cols-4 gap-2">
             {categories.map((cat) => {
               const meta = CATEGORY_META[cat];
@@ -149,12 +150,12 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                   onClick={() => setCategory(cat)}
                   className="flex flex-col items-center gap-1 rounded-xl py-2.5 px-1 transition-colors"
                   style={{
-                    background: selected ? meta.color + '22' : 'rgb(31 41 55)',
+                    background: selected ? meta.color + '22' : 'rgba(255,255,255,0.6)',
                     border: selected ? `2px solid ${meta.color}` : '2px solid transparent',
                   }}
                 >
-                  <Icon size={20} color={selected ? meta.color : '#9CA3AF'} />
-                  <span className="text-xs" style={{ color: selected ? meta.color : '#9CA3AF' }}>
+                  <Icon size={20} color={selected ? meta.color : 'rgba(0,0,0,0.45)'} />
+                  <span className="text-xs" style={{ color: selected ? meta.color : 'rgba(0,0,0,0.45)' }}>
                     {cat}
                   </span>
                 </button>
@@ -165,7 +166,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Frequency */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1.5">Frequency</label>
+          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Frequency</label>
           <div className="flex flex-wrap gap-2">
             {(GAME_CONFIG.habits.frequency_options as HabitFrequencyType[]).map((ft) => (
               <button
@@ -173,8 +174,8 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                 onClick={() => setFreqType(ft)}
                 className="rounded-full px-3.5 py-1.5 text-sm font-medium transition-colors"
                 style={{
-                  background: freqType === ft ? selectedColor + '22' : 'rgb(31 41 55)',
-                  color: freqType === ft ? selectedColor : '#9CA3AF',
+                  background: freqType === ft ? selectedColor + '22' : 'rgba(255,255,255,0.6)',
+                  color: freqType === ft ? selectedColor : 'rgba(0,0,0,0.45)',
                   border: freqType === ft ? `1.5px solid ${selectedColor}` : '1.5px solid transparent',
                 }}
               >
@@ -185,19 +186,19 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
           {/* Times per week stepper */}
           {freqType === 'times_per_week' && (
-            <div className="flex items-center gap-4 mt-3 bg-gray-800 rounded-xl px-4 py-3">
-              <span className="text-sm text-gray-300">Times per week</span>
+            <div className="flex items-center gap-4 mt-3 rounded-xl px-4 py-3" style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}>
+              <span className="text-sm" style={{ color: '#1a1a1a' }}>Times per week</span>
               <div className="flex items-center gap-3 ml-auto">
                 <button
                   onClick={() => setTimesPerWeek(Math.max(1, timesPerWeek - 1))}
-                  className="w-8 h-8 rounded-full bg-gray-700 text-white flex items-center justify-center text-lg active:bg-gray-600"
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-lg" style={{ background: 'rgba(0,0,0,0.06)', color: '#1a1a1a' }}
                 >
                   -
                 </button>
-                <span className="text-white font-semibold w-4 text-center">{timesPerWeek}</span>
+                <span className="font-semibold w-4 text-center" style={{ color: '#1a1a1a' }}>{timesPerWeek}</span>
                 <button
                   onClick={() => setTimesPerWeek(Math.min(7, timesPerWeek + 1))}
-                  className="w-8 h-8 rounded-full bg-gray-700 text-white flex items-center justify-center text-lg active:bg-gray-600"
+                  className="w-8 h-8 rounded-full flex items-center justify-center text-lg" style={{ background: 'rgba(0,0,0,0.06)', color: '#1a1a1a' }}
                 >
                   +
                 </button>
@@ -214,8 +215,8 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                   onClick={() => toggleDay(i)}
                   className="flex-1 py-2 rounded-lg text-xs font-medium transition-colors"
                   style={{
-                    background: specificDays.includes(i) ? selectedColor + '22' : 'rgb(31 41 55)',
-                    color: specificDays.includes(i) ? selectedColor : '#9CA3AF',
+                    background: specificDays.includes(i) ? selectedColor + '22' : 'rgba(255,255,255,0.6)',
+                    color: specificDays.includes(i) ? selectedColor : 'rgba(0,0,0,0.45)',
                     border: specificDays.includes(i) ? `1.5px solid ${selectedColor}` : '1.5px solid transparent',
                   }}
                 >
@@ -228,7 +229,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Difficulty */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1.5">Difficulty</label>
+          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Difficulty</label>
           <div className="space-y-2">
             {difficulties.map((tier) => {
               const selected = difficulty === tier.id;
@@ -240,17 +241,17 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                   onClick={() => setDifficulty(tier.id as HabitDifficulty)}
                   className="w-full text-left rounded-xl px-4 py-3 transition-colors"
                   style={{
-                    background: selected ? selectedColor + '15' : 'rgb(31 41 55)',
+                    background: selected ? selectedColor + '15' : 'rgba(255,255,255,0.6)',
                     border: selected ? `2px solid ${selectedColor}` : '2px solid transparent',
                   }}
                 >
                   <div className="flex items-center justify-between">
-                    <span className="font-semibold text-white">{tier.label}</span>
-                    <span className="text-xs text-gray-400">
+                    <span className="font-semibold" style={{ color: '#1a1a1a' }}>{tier.label}</span>
+                    <span className="text-xs" style={{ color: '#666' }}>
                       +{xp} XP &middot; +{coins} coins
                     </span>
                   </div>
-                  <p className="text-xs text-gray-400 mt-0.5">{tier.description}</p>
+                  <p className="text-xs mt-0.5" style={{ color: '#666' }}>{tier.description}</p>
                 </button>
               );
             })}
@@ -259,7 +260,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Time of Day */}
         <div>
-          <label className="block text-sm text-gray-400 mb-1.5">Time of Day</label>
+          <label className="block text-sm mb-1.5" style={{ color: '#666' }}>Time of Day</label>
           <div className="flex gap-2">
             {TIME_OPTIONS.map((opt) => (
               <button
@@ -267,8 +268,8 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
                 onClick={() => setTimeOfDay(opt.value)}
                 className="flex-1 rounded-xl py-2.5 text-sm font-medium transition-colors"
                 style={{
-                  background: timeOfDay === opt.value ? selectedColor + '22' : 'rgb(31 41 55)',
-                  color: timeOfDay === opt.value ? selectedColor : '#9CA3AF',
+                  background: timeOfDay === opt.value ? selectedColor + '22' : 'rgba(255,255,255,0.6)',
+                  color: timeOfDay === opt.value ? selectedColor : 'rgba(0,0,0,0.45)',
                   border: timeOfDay === opt.value ? `1.5px solid ${selectedColor}` : '1.5px solid transparent',
                 }}
               >
@@ -280,7 +281,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
 
         {/* Start/End Dates */}
         <div>
-          <label className="flex items-center gap-2 text-sm text-gray-400 cursor-pointer">
+          <label className="flex items-center gap-2 text-sm cursor-pointer" style={{ color: '#666' }}>
             <input
               type="checkbox"
               checked={showDates}
@@ -292,28 +293,31 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
           {showDates && (
             <div className="grid grid-cols-2 gap-3 mt-2">
               <div>
-                <span className="text-xs text-gray-500">Start</span>
+                <span className="text-xs" style={{ color: 'rgba(0,0,0,0.35)' }}>Start</span>
                 <input
                   type="date"
                   value={startDate}
                   onChange={(e) => setStartDate(e.target.value)}
-                  className="w-full bg-gray-800 text-white rounded-lg px-3 py-2 text-sm outline-none mt-1"
+                  className="w-full rounded-lg px-3 py-2 text-sm outline-none mt-1"
+                  style={{ background: 'rgba(255,255,255,0.6)', color: '#1a1a1a', border: '1px solid rgba(0,0,0,0.08)' }}
                 />
               </div>
               <div>
-                <span className="text-xs text-gray-500">End (optional)</span>
+                <span className="text-xs" style={{ color: 'rgba(0,0,0,0.35)' }}>End (optional)</span>
                 <div className="relative mt-1">
                   <input
                     type="date"
                     value={endDate}
                     onChange={(e) => setEndDate(e.target.value)}
-                    className="w-full bg-gray-800 text-white rounded-lg px-3 py-2 text-sm outline-none"
+                    className="w-full rounded-lg px-3 py-2 text-sm outline-none"
+                    style={{ background: 'rgba(255,255,255,0.6)', color: '#1a1a1a', border: '1px solid rgba(0,0,0,0.08)' }}
                   />
                   {endDate && (
                     <button
                       type="button"
                       onClick={() => setEndDate('')}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 active:text-white text-lg leading-none"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-lg leading-none"
+                      style={{ color: 'rgba(0,0,0,0.35)' }}
                       aria-label="Clear end date"
                     >
                       &times;
@@ -329,7 +333,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
         {mode === 'edit' && (
           <button
             onClick={() => setShowArchiveConfirm(true)}
-            className="text-sm text-red-400 underline underline-offset-2"
+            className="text-sm text-red-600 underline underline-offset-2"
           >
             Archive this habit
           </button>
@@ -337,7 +341,7 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
       </div>
 
       {/* Save button */}
-      <div className="px-4 pb-[max(env(safe-area-inset-bottom),12px)] pt-3 border-t border-gray-800">
+      <div className="px-4 pb-[max(env(safe-area-inset-bottom),12px)] pt-3" style={{ borderTop: '1px solid rgba(0,0,0,0.06)' }}>
         <button
           onClick={handleSave}
           disabled={!name.trim()}
@@ -356,17 +360,18 @@ export default function HabitForm({ mode, habit, onClose, onSaved }: HabitFormPr
           onClick={() => setShowArchiveConfirm(false)}
         >
           <div
-            className="bg-gray-900 border border-gray-700 rounded-2xl p-5 w-full max-w-xs"
+            className="rounded-2xl p-5 w-full max-w-xs"
+            style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
             onClick={(e) => e.stopPropagation()}
           >
-            <h3 className="text-white font-semibold text-base mb-2">Archive habit?</h3>
-            <p className="text-sm text-gray-400 mb-4">
-              <strong className="text-white">{habit?.name}</strong> won&apos;t appear in check-ins anymore. Historical data is kept.
+            <h3 className="font-semibold text-base mb-2" style={{ color: '#1a1a1a' }}>Archive habit?</h3>
+            <p className="text-sm mb-4" style={{ color: '#666' }}>
+              <strong style={{ color: '#1a1a1a' }}>{habit?.name}</strong> won&apos;t appear in check-ins anymore. Historical data is kept.
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setShowArchiveConfirm(false)}
-                className="flex-1 py-2.5 rounded-xl bg-gray-700 text-sm text-gray-300 active:bg-gray-600"
+                className="flex-1 py-2.5 rounded-xl text-sm" style={{ background: 'transparent', border: '1px solid rgba(0,0,0,0.12)', color: '#666' }}
               >
                 Cancel
               </button>

--- a/src/components/HabitList.tsx
+++ b/src/components/HabitList.tsx
@@ -69,16 +69,19 @@ export default function HabitList({ onClose }: HabitListProps) {
 
       {/* Sheet */}
       <div
-        className="fixed inset-x-0 bottom-0 bg-gray-900 flex flex-col"
+        className="fixed inset-x-0 bottom-0 flex flex-col"
         style={{
           zIndex: 300,
           top: 'env(safe-area-inset-top)',
           paddingBottom: 'max(env(safe-area-inset-bottom), 12px)',
+          background: 'rgba(255, 255, 255, 0.95)',
+          backdropFilter: 'blur(16px)',
+          WebkitBackdropFilter: 'blur(16px)',
         }}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 pt-4 pb-2">
-          <h2 className="text-lg font-semibold text-white">My Habits</h2>
+          <h2 className="text-lg font-semibold" style={{ color: '#1a1a1a' }}>My Habits</h2>
           <div className="flex items-center gap-2">
             <button
               onClick={() => setFormState({ kind: 'create' })}
@@ -86,7 +89,7 @@ export default function HabitList({ onClose }: HabitListProps) {
             >
               <Plus size={18} />
             </button>
-            <button onClick={onClose} className="p-1 text-gray-400 active:text-white">
+            <button onClick={onClose} className="p-1" style={{ color: 'rgba(0,0,0,0.35)' }}>
               <X size={20} />
             </button>
           </div>
@@ -94,7 +97,7 @@ export default function HabitList({ onClose }: HabitListProps) {
 
         {/* Warning banner */}
         {showWarning && (
-          <div className="mx-4 mb-2 px-3 py-2 bg-amber-900/40 border border-amber-700/50 rounded-lg text-xs text-amber-300">
+          <div className="mx-4 mb-2 px-3 py-2 bg-amber-100 border border-amber-300 rounded-lg text-xs text-amber-700">
             You have a lot of habits! Research shows {GAME_CONFIG.habits.recommended_min}-{GAME_CONFIG.habits.recommended_max} is the sweet spot for consistency.
           </div>
         )}
@@ -103,7 +106,7 @@ export default function HabitList({ onClose }: HabitListProps) {
         <div className="flex-1 overflow-y-auto px-4">
           {habits.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
-              <p className="text-gray-400 text-sm mb-4">
+              <p className="text-sm mb-4" style={{ color: '#666' }}>
                 No habits yet. Create your first one to start building your city!
               </p>
               <button
@@ -123,7 +126,8 @@ export default function HabitList({ onClose }: HabitListProps) {
                   <button
                     key={habit.id}
                     onClick={() => setFormState({ kind: 'edit', habit })}
-                    className="w-full flex items-center gap-3 rounded-xl bg-gray-800 px-3.5 py-3 text-left active:bg-gray-750"
+                    className="w-full flex items-center gap-3 rounded-xl px-3.5 py-3 text-left"
+                    style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}
                   >
                     <div
                       className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
@@ -133,7 +137,7 @@ export default function HabitList({ onClose }: HabitListProps) {
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
-                        <span className="text-white text-sm font-medium truncate">
+                        <span className="text-sm font-medium truncate" style={{ color: '#1a1a1a' }}>
                           {habit.name}
                         </span>
                         <span
@@ -146,12 +150,12 @@ export default function HabitList({ onClose }: HabitListProps) {
                           {habit.difficulty.charAt(0).toUpperCase() + habit.difficulty.slice(1)}
                         </span>
                       </div>
-                      <span className="text-xs text-gray-400">{frequencyLabel(habit)}</span>
+                      <span className="text-xs" style={{ color: '#666' }}>{frequencyLabel(habit)}</span>
                     </div>
                     {streak > 0 && (
                       <div className="flex items-center gap-0.5 shrink-0">
-                        <Flame size={14} className="text-orange-400" />
-                        <span className="text-xs font-semibold text-orange-400">{streak}</span>
+                        <Flame size={14} className="text-orange-500" />
+                        <span className="text-xs font-semibold text-orange-500">{streak}</span>
                       </div>
                     )}
                   </button>

--- a/src/components/HabitList.tsx
+++ b/src/components/HabitList.tsx
@@ -74,14 +74,14 @@ export default function HabitList({ onClose }: HabitListProps) {
           zIndex: 300,
           top: 'env(safe-area-inset-top)',
           paddingBottom: 'max(env(safe-area-inset-bottom), 12px)',
-          background: 'rgba(255, 255, 255, 0.95)',
+          background: 'var(--bg-sheet-solid)',
           backdropFilter: 'blur(16px)',
           WebkitBackdropFilter: 'blur(16px)',
         }}
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 pt-4 pb-2">
-          <h2 className="text-lg font-semibold" style={{ color: '#1a1a1a' }}>My Habits</h2>
+          <h2 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>My Habits</h2>
           <div className="flex items-center gap-2">
             <button
               onClick={() => setFormState({ kind: 'create' })}
@@ -89,7 +89,7 @@ export default function HabitList({ onClose }: HabitListProps) {
             >
               <Plus size={18} />
             </button>
-            <button onClick={onClose} className="p-1" style={{ color: 'rgba(0,0,0,0.35)' }}>
+            <button onClick={onClose} className="p-1" style={{ color: 'var(--text-muted)' }}>
               <X size={20} />
             </button>
           </div>
@@ -97,7 +97,7 @@ export default function HabitList({ onClose }: HabitListProps) {
 
         {/* Warning banner */}
         {showWarning && (
-          <div className="mx-4 mb-2 px-3 py-2 bg-amber-100 border border-amber-300 rounded-lg text-xs text-amber-700">
+          <div className="mx-4 mb-2 px-3 py-2 bg-amber-100 dark:bg-amber-500/20 border border-amber-300 dark:border-amber-700/50 rounded-lg text-xs text-amber-700 dark:text-amber-400">
             You have a lot of habits! Research shows {GAME_CONFIG.habits.recommended_min}-{GAME_CONFIG.habits.recommended_max} is the sweet spot for consistency.
           </div>
         )}
@@ -106,7 +106,7 @@ export default function HabitList({ onClose }: HabitListProps) {
         <div className="flex-1 overflow-y-auto px-4">
           {habits.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
-              <p className="text-sm mb-4" style={{ color: '#666' }}>
+              <p className="text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>
                 No habits yet. Create your first one to start building your city!
               </p>
               <button
@@ -127,7 +127,7 @@ export default function HabitList({ onClose }: HabitListProps) {
                     key={habit.id}
                     onClick={() => setFormState({ kind: 'edit', habit })}
                     className="w-full flex items-center gap-3 rounded-xl px-3.5 py-3 text-left"
-                    style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(0,0,0,0.06)' }}
+                    style={{ background: 'var(--bg-card)', border: '1px solid var(--border-subtle)' }}
                   >
                     <div
                       className="w-9 h-9 rounded-lg flex items-center justify-center shrink-0"
@@ -137,7 +137,7 @@ export default function HabitList({ onClose }: HabitListProps) {
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium truncate" style={{ color: '#1a1a1a' }}>
+                        <span className="text-sm font-medium truncate" style={{ color: 'var(--text-primary)' }}>
                           {habit.name}
                         </span>
                         <span
@@ -150,12 +150,12 @@ export default function HabitList({ onClose }: HabitListProps) {
                           {habit.difficulty.charAt(0).toUpperCase() + habit.difficulty.slice(1)}
                         </span>
                       </div>
-                      <span className="text-xs" style={{ color: '#666' }}>{frequencyLabel(habit)}</span>
+                      <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{frequencyLabel(habit)}</span>
                     </div>
                     {streak > 0 && (
                       <div className="flex items-center gap-0.5 shrink-0">
-                        <Flame size={14} className="text-orange-500" />
-                        <span className="text-xs font-semibold text-orange-500">{streak}</span>
+                        <Flame size={14} className="text-orange-500 dark:text-orange-400" />
+                        <span className="text-xs font-semibold text-orange-500 dark:text-orange-400">{streak}</span>
                       </div>
                     )}
                   </button>

--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -70,10 +70,10 @@ export default function MenuButton() {
           width: 48,
           height: 48,
           borderRadius: '50%',
-          background: 'rgba(255, 255, 255, 0.85)',
+          background: 'var(--bg-glass)',
           backdropFilter: 'blur(8px)',
           WebkitBackdropFilter: 'blur(8px)',
-          border: '1px solid rgba(0, 0, 0, 0.08)',
+          border: '1px solid var(--border)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -81,7 +81,7 @@ export default function MenuButton() {
         }}
         aria-label="Open menu"
       >
-        <Equal size={22} color="#444" />
+        <Equal size={22} color="var(--icon-fab)" />
       </button>
 
       {/* Menu sheet */}
@@ -115,10 +115,10 @@ export default function MenuButton() {
                 left: 0,
                 right: 0,
                 zIndex: 92,
-                background: 'rgba(255, 255, 255, 0.92)',
+                background: 'var(--bg-sheet)',
                 backdropFilter: 'blur(20px)',
                 WebkitBackdropFilter: 'blur(20px)',
-                border: '1px solid rgba(0, 0, 0, 0.08)',
+                border: '1px solid var(--border)',
                 borderRadius: '20px 20px 0 0',
                 paddingBottom: 'max(env(safe-area-inset-bottom), 20px)',
               }}
@@ -130,7 +130,7 @@ export default function MenuButton() {
                     width: 36,
                     height: 4,
                     borderRadius: 2,
-                    background: 'rgba(0, 0, 0, 0.15)',
+                    background: 'var(--border-handle)',
                   }}
                 />
               </div>
@@ -156,8 +156,8 @@ export default function MenuButton() {
                         gap: 12,
                         padding: '14px 16px',
                         borderRadius: 14,
-                        background: 'rgba(0, 0, 0, 0.04)',
-                        border: '1px solid rgba(0, 0, 0, 0.06)',
+                        background: 'var(--bg-subtle)',
+                        border: '1px solid var(--border-subtle)',
                         cursor: 'pointer',
                         textAlign: 'left',
                       }}
@@ -176,7 +176,7 @@ export default function MenuButton() {
                       >
                         <Icon size={20} color={item.color} />
                       </div>
-                      <span style={{ fontSize: 16, fontWeight: 500, color: '#1a1a1a' }}>
+                      <span style={{ fontSize: 16, fontWeight: 500, color: 'var(--text-primary)' }}>
                         {item.label}
                       </span>
                     </button>

--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -70,10 +70,10 @@ export default function MenuButton() {
           width: 48,
           height: 48,
           borderRadius: '50%',
-          background: 'rgba(0, 0, 0, 0.6)',
+          background: 'rgba(255, 255, 255, 0.85)',
           backdropFilter: 'blur(8px)',
           WebkitBackdropFilter: 'blur(8px)',
-          border: '1px solid rgba(255,255,255,0.1)',
+          border: '1px solid rgba(0, 0, 0, 0.08)',
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -81,7 +81,7 @@ export default function MenuButton() {
         }}
         aria-label="Open menu"
       >
-        <Equal size={22} color="white" />
+        <Equal size={22} color="#444" />
       </button>
 
       {/* Menu sheet */}
@@ -115,10 +115,10 @@ export default function MenuButton() {
                 left: 0,
                 right: 0,
                 zIndex: 92,
-                background: 'rgba(15, 18, 30, 0.92)',
+                background: 'rgba(255, 255, 255, 0.92)',
                 backdropFilter: 'blur(20px)',
                 WebkitBackdropFilter: 'blur(20px)',
-                border: '1px solid rgba(255,255,255,0.08)',
+                border: '1px solid rgba(0, 0, 0, 0.08)',
                 borderRadius: '20px 20px 0 0',
                 paddingBottom: 'max(env(safe-area-inset-bottom), 20px)',
               }}
@@ -130,7 +130,7 @@ export default function MenuButton() {
                     width: 36,
                     height: 4,
                     borderRadius: 2,
-                    background: 'rgba(255,255,255,0.2)',
+                    background: 'rgba(0, 0, 0, 0.15)',
                   }}
                 />
               </div>
@@ -156,8 +156,8 @@ export default function MenuButton() {
                         gap: 12,
                         padding: '14px 16px',
                         borderRadius: 14,
-                        background: 'rgba(255,255,255,0.06)',
-                        border: '1px solid rgba(255,255,255,0.06)',
+                        background: 'rgba(0, 0, 0, 0.04)',
+                        border: '1px solid rgba(0, 0, 0, 0.06)',
                         cursor: 'pointer',
                         textAlign: 'left',
                       }}
@@ -176,7 +176,7 @@ export default function MenuButton() {
                       >
                         <Icon size={20} color={item.color} />
                       </div>
-                      <span style={{ fontSize: 16, fontWeight: 500, color: 'white' }}>
+                      <span style={{ fontSize: 16, fontWeight: 500, color: '#1a1a1a' }}>
                         {item.label}
                       </span>
                     </button>

--- a/src/components/MonthlyStats.tsx
+++ b/src/components/MonthlyStats.tsx
@@ -157,8 +157,8 @@ function getDayCellColor(rate: number, inMonth: boolean): string {
   if (rate === 100) return 'rgba(16, 185, 129, 0.5)';   // dark green
   if (rate >= 70) return 'rgba(16, 185, 129, 0.3)';     // medium green
   if (rate >= 50) return 'rgba(16, 185, 129, 0.15)';    // light green
-  if (rate > 0) return 'rgba(255, 255, 255, 0.06)';     // light grey
-  return 'rgba(255, 255, 255, 0.02)';                    // empty
+  if (rate > 0) return 'rgba(0, 0, 0, 0.04)';             // light grey
+  return 'rgba(0, 0, 0, 0.02)';                           // empty
 }
 
 const WEEKDAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
@@ -227,7 +227,7 @@ export default function MonthlyStats() {
 
   if (!data) {
     return (
-      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(255,255,255,0.3)' }}>
+      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(0,0,0,0.25)' }}>
         Loading...
       </div>
     );
@@ -243,9 +243,9 @@ export default function MonthlyStats() {
           onClick={goPrev}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4 }}
         >
-          <ChevronLeft size={20} color="rgba(255,255,255,0.6)" />
+          <ChevronLeft size={20} color="rgba(0,0,0,0.45)" />
         </button>
-        <span style={{ fontSize: 16, fontWeight: 600, color: 'white' }}>{monthLabel}</span>
+        <span style={{ fontSize: 16, fontWeight: 600, color: '#1a1a1a' }}>{monthLabel}</span>
         <button
           onClick={goNext}
           style={{
@@ -257,7 +257,7 @@ export default function MonthlyStats() {
           }}
           disabled={isCurrentMonth}
         >
-          <ChevronRight size={20} color="rgba(255,255,255,0.6)" />
+          <ChevronRight size={20} color="rgba(0,0,0,0.45)" />
         </button>
       </div>
 
@@ -266,7 +266,7 @@ export default function MonthlyStats() {
         {/* Weekday headers */}
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 3, marginBottom: 4 }}>
           {WEEKDAY_LABELS.map((d) => (
-            <div key={d} style={{ textAlign: 'center', fontSize: 10, color: 'rgba(255,255,255,0.3)', fontWeight: 500 }}>
+            <div key={d} style={{ textAlign: 'center', fontSize: 10, color: 'rgba(0,0,0,0.3)', fontWeight: 500 }}>
               {d}
             </div>
           ))}
@@ -290,7 +290,7 @@ export default function MonthlyStats() {
                   cursor: day.inMonth && day.rate >= 0 ? 'pointer' : 'default',
                   fontSize: 11,
                   fontWeight: 500,
-                  color: day.inMonth ? 'rgba(255,255,255,0.6)' : 'rgba(255,255,255,0.15)',
+                  color: day.inMonth ? 'rgba(0,0,0,0.55)' : 'rgba(0,0,0,0.15)',
                   outline: tooltip?.date === day.date ? '2px solid rgba(59,130,246,0.5)' : 'none',
                 }}
               >
@@ -305,19 +305,19 @@ export default function MonthlyStats() {
       {tooltip && (
         <div
           style={{
-            background: 'rgba(255,255,255,0.06)',
+            background: 'rgba(0,0,0,0.03)',
             borderRadius: 10,
             padding: '10px 14px',
-            border: '1px solid rgba(255,255,255,0.08)',
+            border: '1px solid rgba(0,0,0,0.06)',
           }}
         >
-          <div style={{ fontSize: 13, fontWeight: 600, color: 'white', marginBottom: 6 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#1a1a1a', marginBottom: 6 }}>
             {new Date(tooltip.date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
             {' — '}
             {tooltip.completed}/{tooltip.scheduled} ({tooltip.rate}%)
           </div>
           {tooltip.habitDetails.map((h) => (
-            <div key={h.name} style={{ fontSize: 12, color: 'rgba(255,255,255,0.5)', marginLeft: 4, marginBottom: 2 }}>
+            <div key={h.name} style={{ fontSize: 12, color: 'rgba(0,0,0,0.45)', marginLeft: 4, marginBottom: 2 }}>
               {h.completed ? '\u2705' : '\u2B1C'} {h.name}
             </div>
           ))}
@@ -327,19 +327,19 @@ export default function MonthlyStats() {
       {/* Per-habit completion rates */}
       {data.habitRates.length > 0 && (
         <section>
-          <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(255,255,255,0.7)', margin: '0 0 12px' }}>
+          <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(0,0,0,0.55)', margin: '0 0 12px' }}>
             Per-Habit Rates
           </h2>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {data.habitRates.map((h) => (
               <div key={h.name}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4, fontSize: 13 }}>
-                  <span style={{ color: 'white' }}>{h.name}</span>
-                  <span style={{ color: 'rgba(255,255,255,0.5)' }}>
+                  <span style={{ color: '#1a1a1a' }}>{h.name}</span>
+                  <span style={{ color: 'rgba(0,0,0,0.45)' }}>
                     {h.completed}/{h.scheduled} ({h.rate}%)
                   </span>
                 </div>
-                <div style={{ height: 6, borderRadius: 3, background: 'rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+                <div style={{ height: 6, borderRadius: 3, background: 'rgba(0,0,0,0.06)', overflow: 'hidden' }}>
                   <div
                     style={{
                       height: '100%',
@@ -359,7 +359,7 @@ export default function MonthlyStats() {
       {trendDiff !== null && (
         <section
           style={{
-            background: 'rgba(255,255,255,0.04)',
+            background: 'rgba(0,0,0,0.03)',
             borderRadius: 14,
             padding: '14px 16px',
             display: 'flex',
@@ -374,10 +374,10 @@ export default function MonthlyStats() {
           ) : (
             <Minus size={20} color="#F59E0B" />
           )}
-          <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.6)' }}>
-            <span style={{ color: 'white', fontWeight: 600 }}>{data.overallRate}%</span> this month
+          <div style={{ fontSize: 13, color: 'rgba(0,0,0,0.45)' }}>
+            <span style={{ color: '#1a1a1a', fontWeight: 600 }}>{data.overallRate}%</span> this month
             {' vs '}
-            <span style={{ color: 'white', fontWeight: 600 }}>{prevRate}%</span> last month
+            <span style={{ color: '#1a1a1a', fontWeight: 600 }}>{prevRate}%</span> last month
             {trendDiff !== 0 && (
               <span style={{ color: trendDiff > 0 ? '#10B981' : '#EF4444', fontWeight: 600 }}>
                 {' '}({trendDiff > 0 ? '+' : ''}{trendDiff}%)
@@ -397,7 +397,7 @@ export default function MonthlyStats() {
         <div
           style={{
             flex: 1,
-            background: 'rgba(255,255,255,0.04)',
+            background: 'rgba(0,0,0,0.03)',
             borderRadius: 14,
             padding: '14px 16px',
             textAlign: 'center',
@@ -407,22 +407,22 @@ export default function MonthlyStats() {
           <div style={{ fontSize: 18, fontWeight: 700, color: '#3b82f6' }}>
             {data.totalXP.toLocaleString()}
           </div>
-          <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>XP earned</div>
+          <div style={{ fontSize: 11, color: 'rgba(0,0,0,0.35)' }}>XP earned</div>
         </div>
         <div
           style={{
             flex: 1,
-            background: 'rgba(255,255,255,0.04)',
+            background: 'rgba(0,0,0,0.03)',
             borderRadius: 14,
             padding: '14px 16px',
             textAlign: 'center',
           }}
         >
           <Coins size={18} color="#facc15" style={{ marginBottom: 4 }} />
-          <div style={{ fontSize: 18, fontWeight: 700, color: '#facc15' }}>
+          <div style={{ fontSize: 18, fontWeight: 700, color: '#ca8a04' }}>
             {data.totalCoins.toLocaleString()}
           </div>
-          <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.4)' }}>Coins earned</div>
+          <div style={{ fontSize: 11, color: 'rgba(0,0,0,0.35)' }}>Coins earned</div>
         </div>
       </section>
     </div>

--- a/src/components/MonthlyStats.tsx
+++ b/src/components/MonthlyStats.tsx
@@ -157,8 +157,8 @@ function getDayCellColor(rate: number, inMonth: boolean): string {
   if (rate === 100) return 'rgba(16, 185, 129, 0.5)';   // dark green
   if (rate >= 70) return 'rgba(16, 185, 129, 0.3)';     // medium green
   if (rate >= 50) return 'rgba(16, 185, 129, 0.15)';    // light green
-  if (rate > 0) return 'rgba(0, 0, 0, 0.04)';             // light grey
-  return 'rgba(0, 0, 0, 0.02)';                           // empty
+  if (rate > 0) return 'var(--bg-subtle)';                  // light grey
+  return 'var(--bg-subtle)';                                // empty
 }
 
 const WEEKDAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
@@ -227,7 +227,7 @@ export default function MonthlyStats() {
 
   if (!data) {
     return (
-      <div style={{ padding: 32, textAlign: 'center', color: 'rgba(0,0,0,0.25)' }}>
+      <div style={{ padding: 32, textAlign: 'center', color: 'var(--text-faint)' }}>
         Loading...
       </div>
     );
@@ -243,9 +243,9 @@ export default function MonthlyStats() {
           onClick={goPrev}
           style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 4 }}
         >
-          <ChevronLeft size={20} color="rgba(0,0,0,0.45)" />
+          <ChevronLeft size={20} color="var(--text-icon)" />
         </button>
-        <span style={{ fontSize: 16, fontWeight: 600, color: '#1a1a1a' }}>{monthLabel}</span>
+        <span style={{ fontSize: 16, fontWeight: 600, color: 'var(--text-primary)' }}>{monthLabel}</span>
         <button
           onClick={goNext}
           style={{
@@ -257,7 +257,7 @@ export default function MonthlyStats() {
           }}
           disabled={isCurrentMonth}
         >
-          <ChevronRight size={20} color="rgba(0,0,0,0.45)" />
+          <ChevronRight size={20} color="var(--text-icon)" />
         </button>
       </div>
 
@@ -290,7 +290,7 @@ export default function MonthlyStats() {
                   cursor: day.inMonth && day.rate >= 0 ? 'pointer' : 'default',
                   fontSize: 11,
                   fontWeight: 500,
-                  color: day.inMonth ? 'rgba(0,0,0,0.55)' : 'rgba(0,0,0,0.15)',
+                  color: day.inMonth ? 'var(--text-label)' : 'var(--border-handle)',
                   outline: tooltip?.date === day.date ? '2px solid rgba(59,130,246,0.5)' : 'none',
                 }}
               >
@@ -305,19 +305,19 @@ export default function MonthlyStats() {
       {tooltip && (
         <div
           style={{
-            background: 'rgba(0,0,0,0.03)',
+            background: 'var(--bg-subtle)',
             borderRadius: 10,
             padding: '10px 14px',
-            border: '1px solid rgba(0,0,0,0.06)',
+            border: '1px solid var(--border-subtle)',
           }}
         >
-          <div style={{ fontSize: 13, fontWeight: 600, color: '#1a1a1a', marginBottom: 6 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)', marginBottom: 6 }}>
             {new Date(tooltip.date + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
             {' — '}
             {tooltip.completed}/{tooltip.scheduled} ({tooltip.rate}%)
           </div>
           {tooltip.habitDetails.map((h) => (
-            <div key={h.name} style={{ fontSize: 12, color: 'rgba(0,0,0,0.45)', marginLeft: 4, marginBottom: 2 }}>
+            <div key={h.name} style={{ fontSize: 12, color: 'var(--text-icon)', marginLeft: 4, marginBottom: 2 }}>
               {h.completed ? '\u2705' : '\u2B1C'} {h.name}
             </div>
           ))}
@@ -327,19 +327,19 @@ export default function MonthlyStats() {
       {/* Per-habit completion rates */}
       {data.habitRates.length > 0 && (
         <section>
-          <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(0,0,0,0.55)', margin: '0 0 12px' }}>
+          <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-label)', margin: '0 0 12px' }}>
             Per-Habit Rates
           </h2>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {data.habitRates.map((h) => (
               <div key={h.name}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4, fontSize: 13 }}>
-                  <span style={{ color: '#1a1a1a' }}>{h.name}</span>
-                  <span style={{ color: 'rgba(0,0,0,0.45)' }}>
+                  <span style={{ color: 'var(--text-primary)' }}>{h.name}</span>
+                  <span style={{ color: 'var(--text-icon)' }}>
                     {h.completed}/{h.scheduled} ({h.rate}%)
                   </span>
                 </div>
-                <div style={{ height: 6, borderRadius: 3, background: 'rgba(0,0,0,0.06)', overflow: 'hidden' }}>
+                <div style={{ height: 6, borderRadius: 3, background: 'var(--bg-track)', overflow: 'hidden' }}>
                   <div
                     style={{
                       height: '100%',
@@ -359,7 +359,7 @@ export default function MonthlyStats() {
       {trendDiff !== null && (
         <section
           style={{
-            background: 'rgba(0,0,0,0.03)',
+            background: 'var(--bg-subtle)',
             borderRadius: 14,
             padding: '14px 16px',
             display: 'flex',
@@ -374,10 +374,10 @@ export default function MonthlyStats() {
           ) : (
             <Minus size={20} color="#F59E0B" />
           )}
-          <div style={{ fontSize: 13, color: 'rgba(0,0,0,0.45)' }}>
-            <span style={{ color: '#1a1a1a', fontWeight: 600 }}>{data.overallRate}%</span> this month
+          <div style={{ fontSize: 13, color: 'var(--text-icon)' }}>
+            <span style={{ color: 'var(--text-primary)', fontWeight: 600 }}>{data.overallRate}%</span> this month
             {' vs '}
-            <span style={{ color: '#1a1a1a', fontWeight: 600 }}>{prevRate}%</span> last month
+            <span style={{ color: 'var(--text-primary)', fontWeight: 600 }}>{prevRate}%</span> last month
             {trendDiff !== 0 && (
               <span style={{ color: trendDiff > 0 ? '#10B981' : '#EF4444', fontWeight: 600 }}>
                 {' '}({trendDiff > 0 ? '+' : ''}{trendDiff}%)
@@ -397,7 +397,7 @@ export default function MonthlyStats() {
         <div
           style={{
             flex: 1,
-            background: 'rgba(0,0,0,0.03)',
+            background: 'var(--bg-subtle)',
             borderRadius: 14,
             padding: '14px 16px',
             textAlign: 'center',
@@ -407,22 +407,22 @@ export default function MonthlyStats() {
           <div style={{ fontSize: 18, fontWeight: 700, color: '#3b82f6' }}>
             {data.totalXP.toLocaleString()}
           </div>
-          <div style={{ fontSize: 11, color: 'rgba(0,0,0,0.35)' }}>XP earned</div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>XP earned</div>
         </div>
         <div
           style={{
             flex: 1,
-            background: 'rgba(0,0,0,0.03)',
+            background: 'var(--bg-subtle)',
             borderRadius: 14,
             padding: '14px 16px',
             textAlign: 'center',
           }}
         >
           <Coins size={18} color="#facc15" style={{ marginBottom: 4 }} />
-          <div style={{ fontSize: 18, fontWeight: 700, color: '#ca8a04' }}>
+          <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--color-coin)' }}>
             {data.totalCoins.toLocaleString()}
           </div>
-          <div style={{ fontSize: 11, color: 'rgba(0,0,0,0.35)' }}>Coins earned</div>
+          <div style={{ fontSize: 11, color: 'var(--text-muted)' }}>Coins earned</div>
         </div>
       </section>
     </div>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -96,16 +96,16 @@ export default function Onboarding() {
   return (
     <div
       className="fixed inset-0 flex flex-col"
-      style={{ zIndex: 9000, background: '#0f172a' }}
+      style={{ zIndex: 9000, background: 'rgba(245, 245, 250, 0.97)' }}
     >
       {/* Step 0: Welcome */}
       {step === 0 && (
         <div className={`flex-1 flex flex-col items-center justify-center px-8 ${fadeClass}`}>
           <div className="text-6xl mb-6">🏘️</div>
-          <h1 className="text-3xl font-bold text-white mb-3 text-center">
+          <h1 className="text-3xl font-bold mb-3 text-center" style={{ color: '#1a1a1a' }}>
             Welcome to HabitVille
           </h1>
-          <p className="text-gray-400 text-center text-base mb-10 max-w-xs">
+          <p className="text-center text-base mb-10 max-w-xs" style={{ color: '#666' }}>
             Your habits build your city. Complete daily goals to earn XP and coins, then build the city of your dreams.
           </p>
           <button
@@ -121,10 +121,10 @@ export default function Onboarding() {
       {step === 1 && !showCustomForm && (
         <div className={`flex-1 flex flex-col ${fadeClass}`}>
           <div className="px-6 pt-[max(env(safe-area-inset-top),24px)] pb-4">
-            <h2 className="text-xl font-bold text-white mb-1">
+            <h2 className="text-xl font-bold mb-1" style={{ color: '#1a1a1a' }}>
               Create your first habits
             </h2>
-            <p className="text-sm text-gray-400">
+            <p className="text-sm" style={{ color: '#666' }}>
               We suggest starting with {GAME_CONFIG.habits.recommended_min}-{GAME_CONFIG.habits.recommended_max} habits. You can always add more later.
             </p>
           </div>
@@ -153,7 +153,7 @@ export default function Onboarding() {
                   onClick={() => toggleSuggestion(i)}
                   className="w-full flex items-center gap-3 rounded-xl px-4 py-3.5 text-left transition-colors"
                   style={{
-                    background: s.enabled ? meta.color + '15' : 'rgb(31 41 55)',
+                    background: s.enabled ? meta.color + '15' : 'rgba(255,255,255,0.6)',
                     border: s.enabled ? `2px solid ${meta.color}50` : '2px solid transparent',
                   }}
                 >
@@ -164,7 +164,7 @@ export default function Onboarding() {
                     <Icon size={20} color={meta.color} />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <span className="text-white text-sm font-medium">{s.name}</span>
+                    <span className="text-sm font-medium" style={{ color: '#1a1a1a' }}>{s.name}</span>
                     <div className="flex items-center gap-2 mt-0.5">
                       <span
                         className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
@@ -172,13 +172,13 @@ export default function Onboarding() {
                       >
                         {s.difficulty.charAt(0).toUpperCase() + s.difficulty.slice(1)}
                       </span>
-                      <span className="text-xs text-gray-400">{s.category}</span>
+                      <span className="text-xs" style={{ color: '#666' }}>{s.category}</span>
                     </div>
                   </div>
                   <div
                     className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
                     style={{
-                      background: s.enabled ? meta.color : 'rgb(55 65 81)',
+                      background: s.enabled ? meta.color : 'rgba(0,0,0,0.08)',
                     }}
                   >
                     {s.enabled && <Check size={14} color="white" />}
@@ -207,7 +207,7 @@ export default function Onboarding() {
                     <Icon size={20} color={meta.color} />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <span className="text-white text-sm font-medium">{h.name}</span>
+                    <span className="text-sm font-medium" style={{ color: '#1a1a1a' }}>{h.name}</span>
                     <div className="flex items-center gap-2 mt-0.5">
                       <span
                         className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
@@ -215,8 +215,8 @@ export default function Onboarding() {
                       >
                         {h.difficulty.charAt(0).toUpperCase() + h.difficulty.slice(1)}
                       </span>
-                      <span className="text-xs text-gray-400">{h.category}</span>
-                      <span className="text-[10px] text-green-400">Custom</span>
+                      <span className="text-xs" style={{ color: '#666' }}>{h.category}</span>
+                      <span className="text-[10px] text-green-600">Custom</span>
                     </div>
                   </div>
                   <div
@@ -231,7 +231,7 @@ export default function Onboarding() {
 
             <button
               onClick={() => setShowCustomForm(true)}
-              className="w-full flex items-center justify-center gap-2 rounded-xl border-2 border-dashed border-gray-600 py-3.5 text-gray-400 text-sm active:border-gray-500 active:text-gray-300"
+              className="w-full flex items-center justify-center gap-2 rounded-xl border-2 border-dashed py-3.5 text-sm" style={{ borderColor: 'rgba(0,0,0,0.15)', color: '#666' }}
             >
               <Plus size={16} />
               Add custom habit
@@ -249,7 +249,7 @@ export default function Onboarding() {
             )}
             <button
               onClick={finish}
-              className="text-sm text-gray-400 active:text-gray-300 py-1"
+              className="text-sm py-1" style={{ color: 'rgba(0,0,0,0.35)' }}
             >
               {totalCount > 0 ? 'Skip suggestions' : 'Skip for now'}
             </button>

--- a/src/components/Onboarding.tsx
+++ b/src/components/Onboarding.tsx
@@ -96,16 +96,16 @@ export default function Onboarding() {
   return (
     <div
       className="fixed inset-0 flex flex-col"
-      style={{ zIndex: 9000, background: 'rgba(245, 245, 250, 0.97)' }}
+      style={{ zIndex: 9000, background: 'var(--bg-page)' }}
     >
       {/* Step 0: Welcome */}
       {step === 0 && (
         <div className={`flex-1 flex flex-col items-center justify-center px-8 ${fadeClass}`}>
           <div className="text-6xl mb-6">🏘️</div>
-          <h1 className="text-3xl font-bold mb-3 text-center" style={{ color: '#1a1a1a' }}>
+          <h1 className="text-3xl font-bold mb-3 text-center" style={{ color: 'var(--text-primary)' }}>
             Welcome to HabitVille
           </h1>
-          <p className="text-center text-base mb-10 max-w-xs" style={{ color: '#666' }}>
+          <p className="text-center text-base mb-10 max-w-xs" style={{ color: 'var(--text-secondary)' }}>
             Your habits build your city. Complete daily goals to earn XP and coins, then build the city of your dreams.
           </p>
           <button
@@ -121,10 +121,10 @@ export default function Onboarding() {
       {step === 1 && !showCustomForm && (
         <div className={`flex-1 flex flex-col ${fadeClass}`}>
           <div className="px-6 pt-[max(env(safe-area-inset-top),24px)] pb-4">
-            <h2 className="text-xl font-bold mb-1" style={{ color: '#1a1a1a' }}>
+            <h2 className="text-xl font-bold mb-1" style={{ color: 'var(--text-primary)' }}>
               Create your first habits
             </h2>
-            <p className="text-sm" style={{ color: '#666' }}>
+            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
               We suggest starting with {GAME_CONFIG.habits.recommended_min}-{GAME_CONFIG.habits.recommended_max} habits. You can always add more later.
             </p>
           </div>
@@ -153,7 +153,7 @@ export default function Onboarding() {
                   onClick={() => toggleSuggestion(i)}
                   className="w-full flex items-center gap-3 rounded-xl px-4 py-3.5 text-left transition-colors"
                   style={{
-                    background: s.enabled ? meta.color + '15' : 'rgba(255,255,255,0.6)',
+                    background: s.enabled ? meta.color + '15' : 'var(--bg-card)',
                     border: s.enabled ? `2px solid ${meta.color}50` : '2px solid transparent',
                   }}
                 >
@@ -164,7 +164,7 @@ export default function Onboarding() {
                     <Icon size={20} color={meta.color} />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <span className="text-sm font-medium" style={{ color: '#1a1a1a' }}>{s.name}</span>
+                    <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{s.name}</span>
                     <div className="flex items-center gap-2 mt-0.5">
                       <span
                         className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
@@ -172,13 +172,13 @@ export default function Onboarding() {
                       >
                         {s.difficulty.charAt(0).toUpperCase() + s.difficulty.slice(1)}
                       </span>
-                      <span className="text-xs" style={{ color: '#666' }}>{s.category}</span>
+                      <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{s.category}</span>
                     </div>
                   </div>
                   <div
                     className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
                     style={{
-                      background: s.enabled ? meta.color : 'rgba(0,0,0,0.08)',
+                      background: s.enabled ? meta.color : 'var(--border)',
                     }}
                   >
                     {s.enabled && <Check size={14} color="white" />}
@@ -207,7 +207,7 @@ export default function Onboarding() {
                     <Icon size={20} color={meta.color} />
                   </div>
                   <div className="flex-1 min-w-0">
-                    <span className="text-sm font-medium" style={{ color: '#1a1a1a' }}>{h.name}</span>
+                    <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>{h.name}</span>
                     <div className="flex items-center gap-2 mt-0.5">
                       <span
                         className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full"
@@ -215,8 +215,8 @@ export default function Onboarding() {
                       >
                         {h.difficulty.charAt(0).toUpperCase() + h.difficulty.slice(1)}
                       </span>
-                      <span className="text-xs" style={{ color: '#666' }}>{h.category}</span>
-                      <span className="text-[10px] text-green-600">Custom</span>
+                      <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>{h.category}</span>
+                      <span className="text-[10px] text-green-600 dark:text-green-400">Custom</span>
                     </div>
                   </div>
                   <div
@@ -231,7 +231,7 @@ export default function Onboarding() {
 
             <button
               onClick={() => setShowCustomForm(true)}
-              className="w-full flex items-center justify-center gap-2 rounded-xl border-2 border-dashed py-3.5 text-sm" style={{ borderColor: 'rgba(0,0,0,0.15)', color: '#666' }}
+              className="w-full flex items-center justify-center gap-2 rounded-xl border-2 border-dashed py-3.5 text-sm" style={{ borderColor: 'var(--border-handle)', color: 'var(--text-secondary)' }}
             >
               <Plus size={16} />
               Add custom habit
@@ -249,7 +249,7 @@ export default function Onboarding() {
             )}
             <button
               onClick={finish}
-              className="text-sm py-1" style={{ color: 'rgba(0,0,0,0.35)' }}
+              className="text-sm py-1" style={{ color: 'var(--text-muted)' }}
             >
               {totalCount > 0 ? 'Skip suggestions' : 'Skip for now'}
             </button>

--- a/src/components/PurchaseConfirmDialog.tsx
+++ b/src/components/PurchaseConfirmDialog.tsx
@@ -27,7 +27,7 @@ export default function PurchaseConfirmDialog({ asset, onConfirm, onCancel }: Pr
       <div
         onClick={(e) => e.stopPropagation()}
         style={{
-          background: 'rgba(255, 255, 255, 0.92)',
+          background: 'var(--bg-sheet)',
           backdropFilter: 'blur(16px)',
           WebkitBackdropFilter: 'blur(16px)',
           borderRadius: 20,
@@ -38,7 +38,7 @@ export default function PurchaseConfirmDialog({ asset, onConfirm, onCancel }: Pr
           flexDirection: 'column',
           alignItems: 'center',
           gap: 16,
-          border: '1px solid rgba(0, 0, 0, 0.08)',
+          border: '1px solid var(--border)',
         }}
       >
         <img
@@ -47,8 +47,8 @@ export default function PurchaseConfirmDialog({ asset, onConfirm, onCancel }: Pr
           style={{ width: 80, height: 80, objectFit: 'contain' }}
         />
         <div style={{ textAlign: 'center' }}>
-          <div style={{ fontSize: 16, fontWeight: 600, color: '#1a1a1a' }}>{asset.name}</div>
-          <div style={{ fontSize: 14, color: '#666', marginTop: 4 }}>
+          <div style={{ fontSize: 16, fontWeight: 600, color: 'var(--text-primary)' }}>{asset.name}</div>
+          <div style={{ fontSize: 14, color: 'var(--text-secondary)', marginTop: 4 }}>
             Buy for <span style={{ fontWeight: 600 }}><img src="/assets/coin/coin.svg" alt="coin" style={{ width: 16, height: 16, display: 'inline', verticalAlign: 'middle' }} /> {asset.price}</span>?
           </div>
         </div>
@@ -59,11 +59,11 @@ export default function PurchaseConfirmDialog({ asset, onConfirm, onCancel }: Pr
               flex: 1,
               padding: '10px 0',
               borderRadius: 12,
-              border: '1px solid rgba(0, 0, 0, 0.12)',
+              border: '1px solid var(--border-strong)',
               background: 'transparent',
               fontSize: 14,
               fontWeight: 500,
-              color: '#666',
+              color: 'var(--text-secondary)',
               cursor: 'pointer',
             }}
           >

--- a/src/components/RoadDeleteConfirm.tsx
+++ b/src/components/RoadDeleteConfirm.tsx
@@ -36,7 +36,7 @@ export default function RoadDeleteConfirm() {
         gap: 10,
         padding: '8px 14px',
         borderRadius: 12,
-        background: 'rgba(255, 255, 255, 0.92)',
+        background: 'var(--bg-sheet)',
         boxShadow: '0 2px 12px rgba(0,0,0,0.15)',
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -13,15 +13,16 @@ export default function SettingsScreen() {
       className="fixed inset-0 flex flex-col"
       style={{
         zIndex: 150,
-        background: 'rgba(10, 12, 20, 0.97)',
+        background: 'rgba(245, 245, 250, 0.97)',
       }}
     >
       {/* Header */}
       <div className="flex items-center justify-between px-4 pt-4 pb-3">
-        <h1 className="text-lg font-semibold text-white">Settings</h1>
+        <h1 className="text-lg font-semibold" style={{ color: '#1a1a1a' }}>Settings</h1>
         <button
           onClick={() => useGameStore.getState().openScreen('city')}
-          className="p-1 text-gray-400 active:text-white"
+          className="p-1"
+          style={{ color: 'rgba(0,0,0,0.35)' }}
           aria-label="Close"
         >
           <X size={22} />
@@ -30,8 +31,8 @@ export default function SettingsScreen() {
 
       {/* Body */}
       <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-8">
-        <Settings2 size={48} className="text-gray-500/40" />
-        <p className="text-gray-400 text-sm">Settings coming soon.</p>
+        <Settings2 size={48} className="text-gray-400/40" />
+        <p className="text-sm" style={{ color: '#666' }}>Settings coming soon.</p>
       </div>
     </div>
   );

--- a/src/components/SettingsScreen.tsx
+++ b/src/components/SettingsScreen.tsx
@@ -1,10 +1,21 @@
 'use client';
 
-import { X, Settings2 } from 'lucide-react';
+import { X, Sun, Moon, Monitor } from 'lucide-react';
 import { useGameStore } from '@/stores/game-store';
+import { useThemeStore } from '@/stores/theme-store';
+
+type ThemeMode = 'light' | 'dark' | 'system';
+
+const THEME_OPTIONS: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'Light', icon: Sun },
+  { value: 'dark', label: 'Dark', icon: Moon },
+  { value: 'system', label: 'System', icon: Monitor },
+];
 
 export default function SettingsScreen() {
   const activeScreen = useGameStore((s) => s.activeScreen);
+  const mode = useThemeStore((s) => s.mode);
+  const setMode = useThemeStore((s) => s.setMode);
 
   if (activeScreen !== 'settings') return null;
 
@@ -13,16 +24,16 @@ export default function SettingsScreen() {
       className="fixed inset-0 flex flex-col"
       style={{
         zIndex: 150,
-        background: 'rgba(245, 245, 250, 0.97)',
+        background: 'var(--bg-page)',
       }}
     >
       {/* Header */}
       <div className="flex items-center justify-between px-4 pt-4 pb-3">
-        <h1 className="text-lg font-semibold" style={{ color: '#1a1a1a' }}>Settings</h1>
+        <h1 className="text-lg font-semibold" style={{ color: 'var(--text-primary)' }}>Settings</h1>
         <button
           onClick={() => useGameStore.getState().openScreen('city')}
           className="p-1"
-          style={{ color: 'rgba(0,0,0,0.35)' }}
+          style={{ color: 'var(--text-muted)' }}
           aria-label="Close"
         >
           <X size={22} />
@@ -30,9 +41,41 @@ export default function SettingsScreen() {
       </div>
 
       {/* Body */}
-      <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center px-8">
-        <Settings2 size={48} className="text-gray-400/40" />
-        <p className="text-sm" style={{ color: '#666' }}>Settings coming soon.</p>
+      <div className="flex-1 overflow-y-auto px-4">
+        {/* Theme section */}
+        <div
+          className="rounded-xl p-4"
+          style={{ background: 'var(--bg-card)', border: '1px solid var(--border-subtle)' }}
+        >
+          <label className="block text-sm font-medium mb-3" style={{ color: 'var(--text-secondary)' }}>
+            Appearance
+          </label>
+          <div className="flex gap-2">
+            {THEME_OPTIONS.map((opt) => {
+              const Icon = opt.icon;
+              const selected = mode === opt.value;
+              return (
+                <button
+                  key={opt.value}
+                  onClick={() => setMode(opt.value)}
+                  className="flex-1 flex flex-col items-center gap-1.5 rounded-xl py-3 transition-colors"
+                  style={{
+                    background: selected ? 'rgba(124, 58, 237, 0.12)' : 'var(--bg-subtle)',
+                    border: selected ? '2px solid #7C3AED' : '2px solid transparent',
+                  }}
+                >
+                  <Icon size={20} color={selected ? '#7C3AED' : 'var(--text-icon)'} />
+                  <span
+                    className="text-xs font-medium"
+                    style={{ color: selected ? '#7C3AED' : 'var(--text-icon)' }}
+                  >
+                    {opt.label}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/ShopAssetCard.tsx
+++ b/src/components/ShopAssetCard.tsx
@@ -92,8 +92,8 @@ export default function ShopAssetCard({ asset }: Props) {
           gap: 4,
           padding: '10px 4px 8px',
           borderRadius: 12,
-          border: '1px solid rgba(0, 0, 0, 0.06)',
-          background: isLocked ? 'rgba(0, 0, 0, 0.03)' : 'rgba(255, 255, 255, 0.6)',
+          border: '1px solid var(--border-subtle)',
+          background: isLocked ? 'var(--bg-subtle)' : 'var(--bg-card)',
           cursor: isLocked ? 'default' : 'pointer',
           position: 'relative',
           opacity: (!isLocked && !isAffordable) ? 0.6 : 1,
@@ -171,7 +171,7 @@ export default function ShopAssetCard({ asset }: Props) {
         <span style={{
           fontSize: 10,
           lineHeight: '12px',
-          color: isLocked ? 'rgba(0,0,0,0.35)' : 'rgba(0,0,0,0.65)',
+          color: isLocked ? 'var(--text-muted)' : 'rgba(0,0,0,0.65)',
           width: '100%',
           textAlign: 'center',
           overflow: 'hidden',
@@ -184,14 +184,14 @@ export default function ShopAssetCard({ asset }: Props) {
 
         {/* Price / Level tag */}
         {isLocked ? (
-          <span style={{ fontSize: 10, fontWeight: 600, color: 'rgba(0,0,0,0.35)' }}>
+          <span style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-muted)' }}>
             Lvl {asset.unlockLevel}
           </span>
         ) : (
           <span style={{
             fontSize: 11,
             fontWeight: 600,
-            color: isAffordable ? '#1a1a1a' : '#DC2626',
+            color: isAffordable ? 'var(--text-primary)' : '#DC2626',
           }}>
             <img src="/assets/coin/coin.svg" alt="coin" style={{ width: 16, height: 16, display: 'inline', verticalAlign: 'middle' }} /> {asset.price}
           </span>

--- a/src/components/ShopAssetCard.tsx
+++ b/src/components/ShopAssetCard.tsx
@@ -171,7 +171,7 @@ export default function ShopAssetCard({ asset }: Props) {
         <span style={{
           fontSize: 10,
           lineHeight: '12px',
-          color: isLocked ? 'var(--text-muted)' : 'rgba(0,0,0,0.65)',
+          color: isLocked ? 'var(--text-muted)' : 'var(--text-label)',
           width: '100%',
           textAlign: 'center',
           overflow: 'hidden',

--- a/src/components/ShopDetailSheet.tsx
+++ b/src/components/ShopDetailSheet.tsx
@@ -86,7 +86,7 @@ export default function ShopDetailSheet() {
           left: 0,
           right: 0,
           zIndex: 160,
-          background: 'rgba(255, 255, 255, 0.92)',
+          background: 'var(--bg-sheet)',
           backdropFilter: 'blur(16px)',
           WebkitBackdropFilter: 'blur(16px)',
           borderTopLeftRadius: 24,
@@ -115,7 +115,7 @@ export default function ShopDetailSheet() {
 
         {/* Name & owned count */}
         <div style={{ textAlign: 'center' }}>
-          <div style={{ fontSize: 18, fontWeight: 600, color: '#1a1a1a' }}>
+          <div style={{ fontSize: 18, fontWeight: 600, color: 'var(--text-primary)' }}>
             {detailAsset.name}
           </div>
           {totalOwned > 0 && (
@@ -159,7 +159,7 @@ export default function ShopDetailSheet() {
             background: affordable
               ? 'linear-gradient(135deg, #7C3AED, #5B21B6)'
               : 'rgba(0, 0, 0, 0.1)',
-            color: affordable ? 'white' : 'rgba(0, 0, 0, 0.35)',
+            color: affordable ? 'white' : 'var(--text-muted)',
             fontSize: 16,
             fontWeight: 600,
             cursor: affordable ? 'pointer' : 'default',

--- a/src/components/ShopScreen.tsx
+++ b/src/components/ShopScreen.tsx
@@ -34,7 +34,7 @@ export default function ShopScreen() {
         position: 'fixed',
         inset: 0,
         zIndex: 150,
-        background: 'rgba(245, 245, 250, 0.97)',
+        background: 'var(--bg-page)',
         backdropFilter: 'blur(20px)',
         WebkitBackdropFilter: 'blur(20px)',
         display: 'flex',
@@ -49,8 +49,8 @@ export default function ShopScreen() {
           alignItems: 'center',
           gap: 12,
           padding: 'max(env(safe-area-inset-top), 12px) 16px 10px',
-          borderBottom: '1px solid rgba(0, 0, 0, 0.06)',
-          background: 'rgba(255, 255, 255, 0.8)',
+          borderBottom: '1px solid var(--border-subtle)',
+          background: 'var(--bg-elevated)',
           backdropFilter: 'blur(12px)',
           WebkitBackdropFilter: 'blur(12px)',
         }}
@@ -73,7 +73,7 @@ export default function ShopScreen() {
           <ArrowLeft size={20} color="#333" />
         </button>
 
-        <span style={{ fontSize: 18, fontWeight: 700, color: '#1a1a1a', flex: 1 }}>Shop</span>
+        <span style={{ fontSize: 18, fontWeight: 700, color: 'var(--text-primary)', flex: 1 }}>Shop</span>
 
         {/* Coin & level display */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -94,14 +94,14 @@ export default function ShopScreen() {
             {level}
           </div>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <span style={{ fontSize: 13, fontWeight: 600, color: '#1a1a1a' }}>
+            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text-primary)' }}>
               <img src="/assets/coin/coin.svg" alt="coin" style={{ width: 16, height: 16, display: 'inline', verticalAlign: 'middle' }} /> {coins.toLocaleString()}
             </span>
             <div style={{
               width: 60,
               height: 3,
               borderRadius: 2,
-              background: 'rgba(0, 0, 0, 0.08)',
+              background: 'var(--bg-track)',
               overflow: 'hidden',
             }}>
               <div style={{
@@ -124,8 +124,8 @@ export default function ShopScreen() {
           overflowX: 'auto',
           WebkitOverflowScrolling: 'touch',
           scrollbarWidth: 'none',
-          borderBottom: '1px solid rgba(0, 0, 0, 0.06)',
-          background: 'rgba(255, 255, 255, 0.6)',
+          borderBottom: '1px solid var(--border-subtle)',
+          background: 'var(--bg-card)',
           flexShrink: 0,
         }}
       >
@@ -139,7 +139,7 @@ export default function ShopScreen() {
               border: 'none',
               background: 'transparent',
               borderBottom: selectedCategory === cat.id ? '2px solid #7C3AED' : '2px solid transparent',
-              color: selectedCategory === cat.id ? '#6D28D9' : 'rgba(0, 0, 0, 0.45)',
+              color: selectedCategory === cat.id ? '#6D28D9' : 'var(--text-icon)',
               fontSize: 13,
               fontWeight: selectedCategory === cat.id ? 600 : 400,
               cursor: 'pointer',

--- a/src/components/ShopScreen.tsx
+++ b/src/components/ShopScreen.tsx
@@ -70,7 +70,7 @@ export default function ShopScreen() {
             flexShrink: 0,
           }}
         >
-          <ArrowLeft size={20} color="#333" />
+          <ArrowLeft size={20} color="var(--text-primary)" />
         </button>
 
         <span style={{ fontSize: 18, fontWeight: 700, color: 'var(--text-primary)', flex: 1 }}>Shop</span>

--- a/src/components/StatsScreen.tsx
+++ b/src/components/StatsScreen.tsx
@@ -25,7 +25,7 @@ export default function StatsScreen() {
         position: 'fixed',
         inset: 0,
         zIndex: 150,
-        background: 'rgba(10, 12, 20, 0.97)',
+        background: 'rgba(245, 245, 250, 0.97)',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
@@ -40,7 +40,7 @@ export default function StatsScreen() {
           padding: 'max(env(safe-area-inset-top), 12px) 16px 10px',
         }}
       >
-        <h1 style={{ fontSize: 20, fontWeight: 700, color: 'white', margin: 0 }}>Stats</h1>
+        <h1 style={{ fontSize: 20, fontWeight: 700, color: '#1a1a1a', margin: 0 }}>Stats</h1>
         <button
           onClick={() => useGameStore.getState().openScreen('city')}
           style={{
@@ -48,7 +48,7 @@ export default function StatsScreen() {
             height: 36,
             borderRadius: '50%',
             border: 'none',
-            background: 'rgba(255,255,255,0.08)',
+            background: 'rgba(0, 0, 0, 0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -56,7 +56,7 @@ export default function StatsScreen() {
           }}
           aria-label="Close"
         >
-          <X size={20} color="rgba(255,255,255,0.6)" />
+          <X size={20} color="rgba(0, 0, 0, 0.35)" />
         </button>
       </div>
 
@@ -66,7 +66,7 @@ export default function StatsScreen() {
           display: 'flex',
           gap: 4,
           padding: '0 16px 12px',
-          background: 'rgba(255,255,255,0.02)',
+          background: 'transparent',
         }}
       >
         {TABS.map((t) => (
@@ -78,8 +78,8 @@ export default function StatsScreen() {
               padding: '8px 0',
               borderRadius: 8,
               border: 'none',
-              background: tab === t.key ? 'rgba(255,255,255,0.1)' : 'transparent',
-              color: tab === t.key ? 'white' : 'rgba(255,255,255,0.4)',
+              background: tab === t.key ? 'rgba(0, 0, 0, 0.06)' : 'transparent',
+              color: tab === t.key ? '#1a1a1a' : 'rgba(0, 0, 0, 0.35)',
               fontSize: 14,
               fontWeight: 600,
               cursor: 'pointer',

--- a/src/components/StatsScreen.tsx
+++ b/src/components/StatsScreen.tsx
@@ -25,7 +25,7 @@ export default function StatsScreen() {
         position: 'fixed',
         inset: 0,
         zIndex: 150,
-        background: 'rgba(245, 245, 250, 0.97)',
+        background: 'var(--bg-page)',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
@@ -40,7 +40,7 @@ export default function StatsScreen() {
           padding: 'max(env(safe-area-inset-top), 12px) 16px 10px',
         }}
       >
-        <h1 style={{ fontSize: 20, fontWeight: 700, color: '#1a1a1a', margin: 0 }}>Stats</h1>
+        <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>Stats</h1>
         <button
           onClick={() => useGameStore.getState().openScreen('city')}
           style={{
@@ -48,7 +48,7 @@ export default function StatsScreen() {
             height: 36,
             borderRadius: '50%',
             border: 'none',
-            background: 'rgba(0, 0, 0, 0.05)',
+            background: 'var(--bg-muted)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -56,7 +56,7 @@ export default function StatsScreen() {
           }}
           aria-label="Close"
         >
-          <X size={20} color="rgba(0, 0, 0, 0.35)" />
+          <X size={20} color="var(--text-muted)" />
         </button>
       </div>
 
@@ -78,8 +78,8 @@ export default function StatsScreen() {
               padding: '8px 0',
               borderRadius: 8,
               border: 'none',
-              background: tab === t.key ? 'rgba(0, 0, 0, 0.06)' : 'transparent',
-              color: tab === t.key ? '#1a1a1a' : 'rgba(0, 0, 0, 0.35)',
+              background: tab === t.key ? 'var(--bg-muted)' : 'transparent',
+              color: tab === t.key ? 'var(--text-primary)' : 'var(--text-muted)',
               fontSize: 14,
               fontWeight: 600,
               cursor: 'pointer',

--- a/src/components/TopHudBar.tsx
+++ b/src/components/TopHudBar.tsx
@@ -119,10 +119,10 @@ export default function TopHudBar() {
         left: 8,
         right: 8,
         zIndex: 85,
-        background: 'rgba(10, 15, 30, 0.75)',
+        background: 'rgba(255, 255, 255, 0.75)',
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',
-        border: '1px solid rgba(255,255,255,0.08)',
+        border: '1px solid rgba(0, 0, 0, 0.08)',
         borderRadius: 14,
         padding: '8px 14px',
         display: 'flex',
@@ -137,7 +137,7 @@ export default function TopHudBar() {
           width: 40,
           height: 40,
           borderRadius: 10,
-          background: 'linear-gradient(135deg, #3b3478, #2a2060)',
+          background: 'linear-gradient(135deg, #7C3AED, #5B21B6)',
           border: '1px solid rgba(139,92,246,0.3)',
           display: 'flex',
           flexDirection: 'column',
@@ -148,7 +148,7 @@ export default function TopHudBar() {
           transform: levelPulse ? 'scale(1.15)' : 'scale(1)',
         }}
       >
-        <span style={{ fontSize: 8, fontWeight: 600, color: 'rgba(255,255,255,0.6)', lineHeight: 1, letterSpacing: 1 }}>
+        <span style={{ fontSize: 8, fontWeight: 600, color: 'rgba(255,255,255,0.8)', lineHeight: 1, letterSpacing: 1 }}>
           LVL
         </span>
         <span style={{ fontSize: 16, fontWeight: 700, color: 'white', lineHeight: 1.1 }}>
@@ -172,7 +172,7 @@ export default function TopHudBar() {
         <span
           style={{
             fontSize: 11,
-            color: 'rgba(255,255,255,0.6)',
+            color: 'rgba(0, 0, 0, 0.45)',
             fontWeight: 500,
             transition: 'transform 0.2s ease',
             transform: xpPulse ? 'scale(1.05)' : 'scale(1)',
@@ -186,7 +186,7 @@ export default function TopHudBar() {
             width: '100%',
             height: 5,
             borderRadius: 3,
-            background: 'rgba(255,255,255,0.1)',
+            background: 'rgba(0, 0, 0, 0.08)',
             overflow: 'hidden',
           }}
         >
@@ -212,7 +212,7 @@ export default function TopHudBar() {
               padding: '6px 10px',
               borderRadius: 8,
               background: 'rgba(0,0,0,0.85)',
-              border: '1px solid rgba(255,255,255,0.1)',
+              border: '1px solid rgba(0, 0, 0, 0.12)',
               fontSize: 11,
               color: 'rgba(255,255,255,0.8)',
               whiteSpace: 'nowrap',
@@ -240,7 +240,7 @@ export default function TopHudBar() {
           style={{
             fontSize: 14,
             fontWeight: 600,
-            color: coinFlash ? '#ef4444' : '#facc15',
+            color: coinFlash ? '#ef4444' : '#ca8a04',
             transition: 'color 0.3s ease',
           }}
         >
@@ -257,12 +257,12 @@ export default function TopHudBar() {
           flexShrink: 0,
         }}
       >
-        <Users size={16} color="rgba(255,255,255,0.5)" />
+        <Users size={16} color="rgba(0, 0, 0, 0.35)" />
         <span
           style={{
             fontSize: 13,
             fontWeight: 500,
-            color: 'rgba(255,255,255,0.6)',
+            color: 'rgba(0, 0, 0, 0.45)',
           }}
         >
           {displayPop.toLocaleString()}

--- a/src/components/TopHudBar.tsx
+++ b/src/components/TopHudBar.tsx
@@ -119,10 +119,10 @@ export default function TopHudBar() {
         left: 8,
         right: 8,
         zIndex: 85,
-        background: 'rgba(255, 255, 255, 0.75)',
+        background: 'var(--bg-hud)',
         backdropFilter: 'blur(12px)',
         WebkitBackdropFilter: 'blur(12px)',
-        border: '1px solid rgba(0, 0, 0, 0.08)',
+        border: '1px solid var(--border)',
         borderRadius: 14,
         padding: '8px 14px',
         display: 'flex',
@@ -137,7 +137,7 @@ export default function TopHudBar() {
           width: 40,
           height: 40,
           borderRadius: 10,
-          background: 'linear-gradient(135deg, #7C3AED, #5B21B6)',
+          background: 'linear-gradient(135deg, var(--level-from), var(--level-to))',
           border: '1px solid rgba(139,92,246,0.3)',
           display: 'flex',
           flexDirection: 'column',
@@ -172,7 +172,7 @@ export default function TopHudBar() {
         <span
           style={{
             fontSize: 11,
-            color: 'rgba(0, 0, 0, 0.45)',
+            color: 'var(--text-icon)',
             fontWeight: 500,
             transition: 'transform 0.2s ease',
             transform: xpPulse ? 'scale(1.05)' : 'scale(1)',
@@ -186,7 +186,7 @@ export default function TopHudBar() {
             width: '100%',
             height: 5,
             borderRadius: 3,
-            background: 'rgba(0, 0, 0, 0.08)',
+            background: 'var(--bg-track)',
             overflow: 'hidden',
           }}
         >
@@ -212,7 +212,7 @@ export default function TopHudBar() {
               padding: '6px 10px',
               borderRadius: 8,
               background: 'rgba(0,0,0,0.85)',
-              border: '1px solid rgba(0, 0, 0, 0.12)',
+              border: '1px solid var(--border-strong)',
               fontSize: 11,
               color: 'rgba(255,255,255,0.8)',
               whiteSpace: 'nowrap',
@@ -240,7 +240,7 @@ export default function TopHudBar() {
           style={{
             fontSize: 14,
             fontWeight: 600,
-            color: coinFlash ? '#ef4444' : '#ca8a04',
+            color: coinFlash ? '#ef4444' : 'var(--color-coin)',
             transition: 'color 0.3s ease',
           }}
         >
@@ -257,12 +257,12 @@ export default function TopHudBar() {
           flexShrink: 0,
         }}
       >
-        <Users size={16} color="rgba(0, 0, 0, 0.35)" />
+        <Users size={16} color="var(--text-muted)" />
         <span
           style={{
             fontSize: 13,
             fontWeight: 500,
-            color: 'rgba(0, 0, 0, 0.45)',
+            color: 'var(--text-icon)',
           }}
         >
           {displayPop.toLocaleString()}

--- a/src/components/TutorialOverlay.tsx
+++ b/src/components/TutorialOverlay.tsx
@@ -44,18 +44,19 @@ export default function TutorialOverlay() {
       onClick={advance}
     >
       <div
-        className="bg-gray-900 border border-gray-700 rounded-2xl px-6 py-5 mx-8 max-w-xs text-center animate-fade-in"
+        className="rounded-2xl px-6 py-5 mx-8 max-w-xs text-center animate-fade-in"
+        style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="text-white font-semibold text-base mb-1.5">{tip.title}</h3>
-        <p className="text-gray-400 text-sm mb-4">{tip.body}</p>
+        <h3 className="font-semibold text-base mb-1.5" style={{ color: '#1a1a1a' }}>{tip.title}</h3>
+        <p className="text-sm mb-4" style={{ color: '#666' }}>{tip.body}</p>
         <button
           onClick={advance}
           className="px-6 py-2 rounded-xl bg-violet-600 text-white text-sm font-medium active:bg-violet-700"
         >
           {isLast ? 'Got it!' : 'Next'}
         </button>
-        <p className="text-gray-500 text-xs mt-3">
+        <p className="text-xs mt-3" style={{ color: 'rgba(0,0,0,0.35)' }}>
           {tutorialStep + 1} / {TIPS.length}
         </p>
       </div>

--- a/src/components/TutorialOverlay.tsx
+++ b/src/components/TutorialOverlay.tsx
@@ -45,18 +45,18 @@ export default function TutorialOverlay() {
     >
       <div
         className="rounded-2xl px-6 py-5 mx-8 max-w-xs text-center animate-fade-in"
-        style={{ background: 'rgba(255,255,255,0.92)', border: '1px solid rgba(0,0,0,0.08)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
+        style={{ background: 'var(--bg-sheet)', border: '1px solid var(--border)', backdropFilter: 'blur(16px)', WebkitBackdropFilter: 'blur(16px)' }}
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="font-semibold text-base mb-1.5" style={{ color: '#1a1a1a' }}>{tip.title}</h3>
-        <p className="text-sm mb-4" style={{ color: '#666' }}>{tip.body}</p>
+        <h3 className="font-semibold text-base mb-1.5" style={{ color: 'var(--text-primary)' }}>{tip.title}</h3>
+        <p className="text-sm mb-4" style={{ color: 'var(--text-secondary)' }}>{tip.body}</p>
         <button
           onClick={advance}
           className="px-6 py-2 rounded-xl bg-violet-600 text-white text-sm font-medium active:bg-violet-700"
         >
           {isLast ? 'Got it!' : 'Next'}
         </button>
-        <p className="text-xs mt-3" style={{ color: 'rgba(0,0,0,0.35)' }}>
+        <p className="text-xs mt-3" style={{ color: 'var(--text-muted)' }}>
           {tutorialStep + 1} / {TIPS.length}
         </p>
       </div>

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -60,7 +60,7 @@ export default function WeeklyReport() {
         position: 'fixed',
         inset: 0,
         zIndex: 150,
-        background: 'rgba(10, 12, 20, 0.97)',
+        background: 'rgba(245, 245, 250, 0.97)',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
@@ -76,10 +76,10 @@ export default function WeeklyReport() {
         }}
       >
         <div>
-          <h1 style={{ fontSize: 20, fontWeight: 700, color: 'white', margin: 0 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 700, color: '#1a1a1a', margin: 0 }}>
             Weekly City Report
           </h1>
-          <span style={{ fontSize: 13, color: 'rgba(255,255,255,0.5)' }}>
+          <span style={{ fontSize: 13, color: 'rgba(0,0,0,0.35)' }}>
             {formatDateRange(snapshot.weekStart)}
           </span>
         </div>
@@ -90,7 +90,7 @@ export default function WeeklyReport() {
             height: 36,
             borderRadius: '50%',
             border: 'none',
-            background: 'rgba(255,255,255,0.08)',
+            background: 'rgba(0, 0, 0, 0.05)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -98,7 +98,7 @@ export default function WeeklyReport() {
           }}
           aria-label="Close"
         >
-          <X size={20} color="rgba(255,255,255,0.6)" />
+          <X size={20} color="rgba(0, 0, 0, 0.35)" />
         </button>
       </div>
 
@@ -119,14 +119,14 @@ export default function WeeklyReport() {
         </div>
 
         {/* Summary line */}
-        <div style={{ textAlign: 'center', color: 'rgba(255,255,255,0.6)', fontSize: 14 }}>
+        <div style={{ textAlign: 'center', color: 'rgba(0,0,0,0.45)', fontSize: 14 }}>
           {snapshot.totalCompleted} of {snapshot.totalScheduled} habits completed
         </div>
 
         {/* Per-habit breakdown */}
         {sortedHabits.length > 0 && (
           <section>
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(255,255,255,0.7)', margin: '0 0 12px' }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(0,0,0,0.55)', margin: '0 0 12px' }}>
               Habit Breakdown
             </h2>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
@@ -142,8 +142,8 @@ export default function WeeklyReport() {
                         fontSize: 13,
                       }}
                     >
-                      <span style={{ color: 'white' }}>{h.habitName}</span>
-                      <span style={{ color: 'rgba(255,255,255,0.5)' }}>
+                      <span style={{ color: '#1a1a1a' }}>{h.habitName}</span>
+                      <span style={{ color: 'rgba(0,0,0,0.45)' }}>
                         {h.completed}/{h.scheduled} ({rate}%)
                       </span>
                     </div>
@@ -151,7 +151,7 @@ export default function WeeklyReport() {
                       style={{
                         height: 6,
                         borderRadius: 3,
-                        background: 'rgba(255,255,255,0.08)',
+                        background: 'rgba(0,0,0,0.06)',
                         overflow: 'hidden',
                       }}
                     >
@@ -176,22 +176,22 @@ export default function WeeklyReport() {
         {/* XP Earned */}
         <section
           style={{
-            background: 'rgba(255,255,255,0.04)',
+            background: 'rgba(0,0,0,0.03)',
             borderRadius: 14,
             padding: '14px 16px',
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
             <Zap size={18} color="#3b82f6" />
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'white', margin: 0 }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: '#1a1a1a', margin: 0 }}>
               XP Earned
             </h2>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 4 }}>
             <span>Base tasks</span>
             <span>+{snapshot.baseXPEarned.toLocaleString()} XP</span>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 8 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 8 }}>
             <span>Weekly bonus ({snapshot.consistencyTier})</span>
             <span>+{snapshot.bonusXPEarned.toLocaleString()} XP</span>
           </div>
@@ -204,26 +204,26 @@ export default function WeeklyReport() {
         {/* Coins Earned */}
         <section
           style={{
-            background: 'rgba(255,255,255,0.04)',
+            background: 'rgba(0,0,0,0.03)',
             borderRadius: 14,
             padding: '14px 16px',
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-            <Coins size={18} color="#facc15" />
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'white', margin: 0 }}>
+            <Coins size={18} color="#ca8a04" />
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: '#1a1a1a', margin: 0 }}>
               Coins Earned
             </h2>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 4 }}>
             <span>Base tasks</span>
             <span>+{snapshot.baseCoinEarned.toLocaleString()}</span>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(255,255,255,0.5)', marginBottom: 8 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 8 }}>
             <span>Weekly bonus ({snapshot.consistencyTier})</span>
             <span>+{snapshot.bonusCoinEarned.toLocaleString()}</span>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 16, fontWeight: 700, color: '#facc15' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 16, fontWeight: 700, color: '#ca8a04' }}>
             <span>Total</span>
             <span>+{totalCoins.toLocaleString()}</span>
           </div>
@@ -232,21 +232,21 @@ export default function WeeklyReport() {
         {/* Weekly Bonus Reveal */}
         <section
           style={{
-            background: 'linear-gradient(135deg, rgba(139,92,246,0.15), rgba(59,130,246,0.15))',
-            border: '1px solid rgba(139,92,246,0.2)',
+            background: 'linear-gradient(135deg, rgba(124,58,237,0.08), rgba(59,130,246,0.08))',
+            border: '1px solid rgba(124,58,237,0.15)',
             borderRadius: 14,
             padding: '20px 16px',
             textAlign: 'center',
           }}
         >
           <TrendingUp size={28} color="#8b5cf6" style={{ marginBottom: 8 }} />
-          <div style={{ fontSize: 14, color: 'rgba(255,255,255,0.6)', marginBottom: 4 }}>
+          <div style={{ fontSize: 14, color: 'rgba(0,0,0,0.45)', marginBottom: 4 }}>
             Consistency Bonus
           </div>
           <div style={{ fontSize: 32, fontWeight: 800, color: '#8b5cf6', lineHeight: 1.1 }}>
             {snapshot.consistencyTier} Bonus!
           </div>
-          <div style={{ fontSize: 13, color: 'rgba(255,255,255,0.5)', marginTop: 8 }}>
+          <div style={{ fontSize: 13, color: 'rgba(0,0,0,0.45)', marginTop: 8 }}>
             +{snapshot.bonusXPEarned.toLocaleString()} XP &middot; +{snapshot.bonusCoinEarned.toLocaleString()} Coins
           </div>
         </section>

--- a/src/components/WeeklyReport.tsx
+++ b/src/components/WeeklyReport.tsx
@@ -60,7 +60,7 @@ export default function WeeklyReport() {
         position: 'fixed',
         inset: 0,
         zIndex: 150,
-        background: 'rgba(245, 245, 250, 0.97)',
+        background: 'var(--bg-page)',
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
@@ -76,10 +76,10 @@ export default function WeeklyReport() {
         }}
       >
         <div>
-          <h1 style={{ fontSize: 20, fontWeight: 700, color: '#1a1a1a', margin: 0 }}>
+          <h1 style={{ fontSize: 20, fontWeight: 700, color: 'var(--text-primary)', margin: 0 }}>
             Weekly City Report
           </h1>
-          <span style={{ fontSize: 13, color: 'rgba(0,0,0,0.35)' }}>
+          <span style={{ fontSize: 13, color: 'var(--text-muted)' }}>
             {formatDateRange(snapshot.weekStart)}
           </span>
         </div>
@@ -90,7 +90,7 @@ export default function WeeklyReport() {
             height: 36,
             borderRadius: '50%',
             border: 'none',
-            background: 'rgba(0, 0, 0, 0.05)',
+            background: 'var(--bg-muted)',
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
@@ -98,7 +98,7 @@ export default function WeeklyReport() {
           }}
           aria-label="Close"
         >
-          <X size={20} color="rgba(0, 0, 0, 0.35)" />
+          <X size={20} color="var(--text-muted)" />
         </button>
       </div>
 
@@ -119,14 +119,14 @@ export default function WeeklyReport() {
         </div>
 
         {/* Summary line */}
-        <div style={{ textAlign: 'center', color: 'rgba(0,0,0,0.45)', fontSize: 14 }}>
+        <div style={{ textAlign: 'center', color: 'var(--text-icon)', fontSize: 14 }}>
           {snapshot.totalCompleted} of {snapshot.totalScheduled} habits completed
         </div>
 
         {/* Per-habit breakdown */}
         {sortedHabits.length > 0 && (
           <section>
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'rgba(0,0,0,0.55)', margin: '0 0 12px' }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-label)', margin: '0 0 12px' }}>
               Habit Breakdown
             </h2>
             <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
@@ -142,8 +142,8 @@ export default function WeeklyReport() {
                         fontSize: 13,
                       }}
                     >
-                      <span style={{ color: '#1a1a1a' }}>{h.habitName}</span>
-                      <span style={{ color: 'rgba(0,0,0,0.45)' }}>
+                      <span style={{ color: 'var(--text-primary)' }}>{h.habitName}</span>
+                      <span style={{ color: 'var(--text-icon)' }}>
                         {h.completed}/{h.scheduled} ({rate}%)
                       </span>
                     </div>
@@ -151,7 +151,7 @@ export default function WeeklyReport() {
                       style={{
                         height: 6,
                         borderRadius: 3,
-                        background: 'rgba(0,0,0,0.06)',
+                        background: 'var(--bg-track)',
                         overflow: 'hidden',
                       }}
                     >
@@ -176,22 +176,22 @@ export default function WeeklyReport() {
         {/* XP Earned */}
         <section
           style={{
-            background: 'rgba(0,0,0,0.03)',
+            background: 'var(--bg-subtle)',
             borderRadius: 14,
             padding: '14px 16px',
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
             <Zap size={18} color="#3b82f6" />
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: '#1a1a1a', margin: 0 }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-primary)', margin: 0 }}>
               XP Earned
             </h2>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'var(--text-icon)', marginBottom: 4 }}>
             <span>Base tasks</span>
             <span>+{snapshot.baseXPEarned.toLocaleString()} XP</span>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 8 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'var(--text-icon)', marginBottom: 8 }}>
             <span>Weekly bonus ({snapshot.consistencyTier})</span>
             <span>+{snapshot.bonusXPEarned.toLocaleString()} XP</span>
           </div>
@@ -204,26 +204,26 @@ export default function WeeklyReport() {
         {/* Coins Earned */}
         <section
           style={{
-            background: 'rgba(0,0,0,0.03)',
+            background: 'var(--bg-subtle)',
             borderRadius: 14,
             padding: '14px 16px',
           }}
         >
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-            <Coins size={18} color="#ca8a04" />
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: '#1a1a1a', margin: 0 }}>
+            <Coins size={18} color="var(--color-coin)" />
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: 'var(--text-primary)', margin: 0 }}>
               Coins Earned
             </h2>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 4 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'var(--text-icon)', marginBottom: 4 }}>
             <span>Base tasks</span>
             <span>+{snapshot.baseCoinEarned.toLocaleString()}</span>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'rgba(0,0,0,0.45)', marginBottom: 8 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 13, color: 'var(--text-icon)', marginBottom: 8 }}>
             <span>Weekly bonus ({snapshot.consistencyTier})</span>
             <span>+{snapshot.bonusCoinEarned.toLocaleString()}</span>
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 16, fontWeight: 700, color: '#ca8a04' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 16, fontWeight: 700, color: 'var(--color-coin)' }}>
             <span>Total</span>
             <span>+{totalCoins.toLocaleString()}</span>
           </div>
@@ -232,7 +232,7 @@ export default function WeeklyReport() {
         {/* Weekly Bonus Reveal */}
         <section
           style={{
-            background: 'linear-gradient(135deg, rgba(124,58,237,0.08), rgba(59,130,246,0.08))',
+            background: 'linear-gradient(135deg, var(--level-section), rgba(59,130,246,0.08))',
             border: '1px solid rgba(124,58,237,0.15)',
             borderRadius: 14,
             padding: '20px 16px',
@@ -240,13 +240,13 @@ export default function WeeklyReport() {
           }}
         >
           <TrendingUp size={28} color="#8b5cf6" style={{ marginBottom: 8 }} />
-          <div style={{ fontSize: 14, color: 'rgba(0,0,0,0.45)', marginBottom: 4 }}>
+          <div style={{ fontSize: 14, color: 'var(--text-icon)', marginBottom: 4 }}>
             Consistency Bonus
           </div>
           <div style={{ fontSize: 32, fontWeight: 800, color: '#8b5cf6', lineHeight: 1.1 }}>
             {snapshot.consistencyTier} Bonus!
           </div>
-          <div style={{ fontSize: 13, color: 'rgba(0,0,0,0.45)', marginTop: 8 }}>
+          <div style={{ fontSize: 13, color: 'var(--text-icon)', marginTop: 8 }}>
             +{snapshot.bonusXPEarned.toLocaleString()} XP &middot; +{snapshot.bonusCoinEarned.toLocaleString()} Coins
           </div>
         </section>

--- a/src/components/WeeklyView.tsx
+++ b/src/components/WeeklyView.tsx
@@ -166,12 +166,12 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
       <div className="flex items-center justify-between px-4 py-2">
         <button
           onClick={goToPreviousWeek}
-          className="flex items-center gap-1 text-sm transition-colors" style={{ color: '#666' }}
+          className="flex items-center gap-1 text-sm transition-colors" style={{ color: 'var(--text-secondary)' }}
         >
           <ChevronLeft size={16} />
           <span>Prev</span>
         </button>
-        <span className="text-sm font-medium" style={{ color: '#1a1a1a' }}>
+        <span className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
           {formatWeekRange(displayDates)}
         </span>
         {isPastWeek ? (
@@ -189,8 +189,8 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
 
       {/* Past week indicator */}
       {isPastWeek && (
-        <div className="mx-4 mb-2 py-1.5 px-3 rounded-lg text-center" style={{ background: 'rgba(0,0,0,0.06)' }}>
-          <span className="text-xs" style={{ color: 'rgba(0,0,0,0.35)' }}>Past week — read only</span>
+        <div className="mx-4 mb-2 py-1.5 px-3 rounded-lg text-center" style={{ background: 'var(--bg-muted)' }}>
+          <span className="text-xs" style={{ color: 'var(--text-muted)' }}>Past week — read only</span>
         </div>
       )}
 
@@ -224,7 +224,7 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                     isToday ? 'bg-violet-600/15' : ''
                   }`}
                 >
-                  <span className={`text-xs font-medium ${isToday ? 'text-violet-700' : 'text-[#666]'}`}>
+                  <span className={`text-xs font-medium ${isToday ? 'text-violet-700 dark:text-violet-300' : 'text-[#666] dark:text-gray-400'}`}>
                     {DAY_LABELS[i]}
                   </span>
                   <span className={`text-lg font-bold ${isToday ? 'text-[#1a1a1a]' : 'text-[#1a1a1a]'}`}>
@@ -243,7 +243,7 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                         className="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-lg"
                       >
                         {isCompleted ? (
-                          <Check size={14} className="text-emerald-600 shrink-0" />
+                          <Check size={14} className="text-emerald-600 dark:text-emerald-400 shrink-0" />
                         ) : (
                           <Circle size={14} className="text-[rgba(0,0,0,0.25)] shrink-0" />
                         )}
@@ -258,7 +258,7 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                     );
                   })}
                   {dayHabits.length === 0 && (
-                    <p className="text-[10px] text-center py-2" style={{ color: 'rgba(0,0,0,0.25)' }}>No habits</p>
+                    <p className="text-[10px] text-center py-2" style={{ color: 'var(--text-faint)' }}>No habits</p>
                   )}
                 </div>
               </button>
@@ -268,9 +268,9 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
       </div>
 
       {/* Footer — progress bar + stats */}
-      <div className="shrink-0 px-4 pt-3 pb-4" style={{ borderTop: '1px solid rgba(0,0,0,0.06)' }}>
+      <div className="shrink-0 px-4 pt-3 pb-4" style={{ borderTop: '1px solid var(--border-subtle)' }}>
         {/* Progress bar */}
-        <div className="w-full h-2 rounded-full mb-3 overflow-hidden" style={{ background: 'rgba(0,0,0,0.08)' }}>
+        <div className="w-full h-2 rounded-full mb-3 overflow-hidden" style={{ background: 'var(--bg-track)' }}>
           <div
             className="h-full rounded-full transition-all duration-500"
             style={{
@@ -285,18 +285,18 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
         </div>
         <div className="flex items-center justify-between">
           <div>
-            <span className="text-base font-bold" style={{ color: '#1a1a1a' }}>
+            <span className="text-base font-bold" style={{ color: 'var(--text-primary)' }}>
               {weeklyStats.totalCompleted}/{weeklyStats.totalScheduled}
             </span>
-            <span className="text-sm ml-1.5" style={{ color: '#666' }}>
+            <span className="text-sm ml-1.5" style={{ color: 'var(--text-secondary)' }}>
               completed ({weeklyStats.percentage}%)
             </span>
           </div>
           <div className={`text-sm font-semibold px-2.5 py-1 rounded-full ${
             weeklyStats.multiplier >= 2
-              ? 'bg-emerald-100 text-emerald-700'
+              ? 'bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-400'
               : weeklyStats.multiplier >= 1
-                ? 'bg-amber-100 text-amber-700'
+                ? 'bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400'
                 : weeklyStats.multiplier > 0
                   ? 'bg-[rgba(0,0,0,0.06)] text-[#666]'
                   : 'bg-[rgba(0,0,0,0.04)] text-[rgba(0,0,0,0.35)]'
@@ -307,7 +307,7 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
           </div>
         </div>
         {(weeklyStats.xpEarned > 0 || weeklyStats.coinsEarned > 0) && (
-          <div className="text-xs mt-1.5" style={{ color: 'rgba(0,0,0,0.35)' }}>
+          <div className="text-xs mt-1.5" style={{ color: 'var(--text-muted)' }}>
             +{weeklyStats.xpEarned.toLocaleString()} XP &middot; +{weeklyStats.coinsEarned.toLocaleString()} Coins this week
           </div>
         )}

--- a/src/components/WeeklyView.tsx
+++ b/src/components/WeeklyView.tsx
@@ -224,10 +224,10 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                     isToday ? 'bg-violet-600/15' : ''
                   }`}
                 >
-                  <span className={`text-xs font-medium ${isToday ? 'text-violet-700 dark:text-violet-300' : 'text-[#666] dark:text-gray-400'}`}>
+                  <span className={`text-xs font-medium ${isToday ? 'text-violet-700 dark:text-violet-300' : ''}`} style={isToday ? undefined : { color: 'var(--text-secondary)' }}>
                     {DAY_LABELS[i]}
                   </span>
-                  <span className={`text-lg font-bold ${isToday ? 'text-[#1a1a1a]' : 'text-[#1a1a1a]'}`}>
+                  <span className="text-lg font-bold" style={{ color: 'var(--text-primary)' }}>
                     {parseInt(dayNum)}
                   </span>
                 </div>
@@ -245,12 +245,11 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                         {isCompleted ? (
                           <Check size={14} className="text-emerald-600 dark:text-emerald-400 shrink-0" />
                         ) : (
-                          <Circle size={14} className="text-[rgba(0,0,0,0.25)] shrink-0" />
+                          <Circle size={14} className="shrink-0" style={{ color: 'var(--text-faint)' }} />
                         )}
                         <span
-                          className={`text-xs truncate ${
-                            isCompleted ? 'text-[rgba(0,0,0,0.35)] line-through' : 'text-[#1a1a1a]'
-                          }`}
+                          className={`text-xs truncate ${isCompleted ? 'line-through' : ''}`}
+                          style={{ color: isCompleted ? 'var(--text-muted)' : 'var(--text-primary)' }}
                         >
                           {habit.name}
                         </span>
@@ -298,8 +297,8 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
               : weeklyStats.multiplier >= 1
                 ? 'bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400'
                 : weeklyStats.multiplier > 0
-                  ? 'bg-[rgba(0,0,0,0.06)] text-[#666]'
-                  : 'bg-[rgba(0,0,0,0.04)] text-[rgba(0,0,0,0.35)]'
+                  ? 'bg-[rgba(0,0,0,0.06)] dark:bg-[rgba(255,255,255,0.1)] text-[#666] dark:text-gray-400'
+                  : 'bg-[rgba(0,0,0,0.04)] dark:bg-[rgba(255,255,255,0.06)] text-[rgba(0,0,0,0.35)] dark:text-gray-500'
           }`}>
             {weeklyStats.multiplier > 0
               ? `${weeklyStats.multiplier}x bonus`

--- a/src/components/WeeklyView.tsx
+++ b/src/components/WeeklyView.tsx
@@ -166,12 +166,12 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
       <div className="flex items-center justify-between px-4 py-2">
         <button
           onClick={goToPreviousWeek}
-          className="flex items-center gap-1 text-sm text-gray-400 active:text-white transition-colors"
+          className="flex items-center gap-1 text-sm transition-colors" style={{ color: '#666' }}
         >
           <ChevronLeft size={16} />
           <span>Prev</span>
         </button>
-        <span className="text-sm font-medium text-gray-300">
+        <span className="text-sm font-medium" style={{ color: '#1a1a1a' }}>
           {formatWeekRange(displayDates)}
         </span>
         {isPastWeek ? (
@@ -189,8 +189,8 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
 
       {/* Past week indicator */}
       {isPastWeek && (
-        <div className="mx-4 mb-2 py-1.5 px-3 rounded-lg bg-gray-800/60 text-center">
-          <span className="text-xs text-gray-500">Past week — read only</span>
+        <div className="mx-4 mb-2 py-1.5 px-3 rounded-lg text-center" style={{ background: 'rgba(0,0,0,0.06)' }}>
+          <span className="text-xs" style={{ color: 'rgba(0,0,0,0.35)' }}>Past week — read only</span>
         </div>
       )}
 
@@ -216,18 +216,18 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                 disabled={!tappable}
                 className={`flex flex-col rounded-xl flex-1 min-w-[170px] text-left ${getColumnClasses(date)} ${
                   isToday ? 'ring-2 ring-violet-500/50' : ''
-                } ${tappable ? 'active:bg-gray-700/30 cursor-pointer' : 'cursor-default'}`}
+                } ${tappable ? 'active:bg-[rgba(0,0,0,0.04)] cursor-pointer' : 'cursor-default'}`}
               >
                 {/* Day header */}
                 <div
                   className={`flex flex-col items-center py-2.5 rounded-t-xl ${
-                    isToday ? 'bg-violet-600/20' : ''
+                    isToday ? 'bg-violet-600/15' : ''
                   }`}
                 >
-                  <span className={`text-xs font-medium ${isToday ? 'text-violet-300' : 'text-gray-400'}`}>
+                  <span className={`text-xs font-medium ${isToday ? 'text-violet-700' : 'text-[#666]'}`}>
                     {DAY_LABELS[i]}
                   </span>
-                  <span className={`text-lg font-bold ${isToday ? 'text-white' : 'text-gray-300'}`}>
+                  <span className={`text-lg font-bold ${isToday ? 'text-[#1a1a1a]' : 'text-[#1a1a1a]'}`}>
                     {parseInt(dayNum)}
                   </span>
                 </div>
@@ -243,13 +243,13 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                         className="w-full flex items-center gap-1.5 px-2 py-1.5 rounded-lg"
                       >
                         {isCompleted ? (
-                          <Check size={14} className="text-emerald-400 shrink-0" />
+                          <Check size={14} className="text-emerald-600 shrink-0" />
                         ) : (
-                          <Circle size={14} className="text-gray-500 shrink-0" />
+                          <Circle size={14} className="text-[rgba(0,0,0,0.25)] shrink-0" />
                         )}
                         <span
                           className={`text-xs truncate ${
-                            isCompleted ? 'text-gray-500 line-through' : 'text-gray-300'
+                            isCompleted ? 'text-[rgba(0,0,0,0.35)] line-through' : 'text-[#1a1a1a]'
                           }`}
                         >
                           {habit.name}
@@ -258,7 +258,7 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
                     );
                   })}
                   {dayHabits.length === 0 && (
-                    <p className="text-[10px] text-gray-600 text-center py-2">No habits</p>
+                    <p className="text-[10px] text-center py-2" style={{ color: 'rgba(0,0,0,0.25)' }}>No habits</p>
                   )}
                 </div>
               </button>
@@ -268,9 +268,9 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
       </div>
 
       {/* Footer — progress bar + stats */}
-      <div className="shrink-0 px-4 pt-3 pb-4 border-t border-gray-800">
+      <div className="shrink-0 px-4 pt-3 pb-4" style={{ borderTop: '1px solid rgba(0,0,0,0.06)' }}>
         {/* Progress bar */}
-        <div className="w-full h-2 rounded-full bg-gray-800 mb-3 overflow-hidden">
+        <div className="w-full h-2 rounded-full mb-3 overflow-hidden" style={{ background: 'rgba(0,0,0,0.08)' }}>
           <div
             className="h-full rounded-full transition-all duration-500"
             style={{
@@ -285,21 +285,21 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
         </div>
         <div className="flex items-center justify-between">
           <div>
-            <span className="text-base font-bold text-white">
+            <span className="text-base font-bold" style={{ color: '#1a1a1a' }}>
               {weeklyStats.totalCompleted}/{weeklyStats.totalScheduled}
             </span>
-            <span className="text-sm text-gray-400 ml-1.5">
+            <span className="text-sm ml-1.5" style={{ color: '#666' }}>
               completed ({weeklyStats.percentage}%)
             </span>
           </div>
           <div className={`text-sm font-semibold px-2.5 py-1 rounded-full ${
             weeklyStats.multiplier >= 2
-              ? 'bg-emerald-500/20 text-emerald-400'
+              ? 'bg-emerald-100 text-emerald-700'
               : weeklyStats.multiplier >= 1
-                ? 'bg-amber-500/20 text-amber-400'
+                ? 'bg-amber-100 text-amber-700'
                 : weeklyStats.multiplier > 0
-                  ? 'bg-gray-700 text-gray-300'
-                  : 'bg-gray-800 text-gray-500'
+                  ? 'bg-[rgba(0,0,0,0.06)] text-[#666]'
+                  : 'bg-[rgba(0,0,0,0.04)] text-[rgba(0,0,0,0.35)]'
           }`}>
             {weeklyStats.multiplier > 0
               ? `${weeklyStats.multiplier}x bonus`
@@ -307,7 +307,7 @@ export default function WeeklyView({ weekDates, todayStr, onSelectDay }: WeeklyV
           </div>
         </div>
         {(weeklyStats.xpEarned > 0 || weeklyStats.coinsEarned > 0) && (
-          <div className="text-xs text-gray-500 mt-1.5">
+          <div className="text-xs mt-1.5" style={{ color: 'rgba(0,0,0,0.35)' }}>
             +{weeklyStats.xpEarned.toLocaleString()} XP &middot; +{weeklyStats.coinsEarned.toLocaleString()} Coins this week
           </div>
         )}

--- a/src/stores/theme-store.ts
+++ b/src/stores/theme-store.ts
@@ -1,0 +1,66 @@
+import { create } from 'zustand';
+
+type ThemeMode = 'light' | 'dark' | 'system';
+type ResolvedTheme = 'light' | 'dark';
+
+interface ThemeState {
+  mode: ThemeMode;
+  resolved: ResolvedTheme;
+  initialize: () => void;
+  setMode: (mode: ThemeMode) => void;
+}
+
+const STORAGE_KEY = 'habitville-theme';
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(resolved: ResolvedTheme) {
+  if (typeof document === 'undefined') return;
+  const el = document.documentElement;
+  if (resolved === 'dark') {
+    el.classList.add('dark');
+  } else {
+    el.classList.remove('dark');
+  }
+}
+
+function resolveMode(mode: ThemeMode): ResolvedTheme {
+  return mode === 'system' ? getSystemTheme() : mode;
+}
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  mode: 'light',
+  resolved: 'light',
+
+  initialize: () => {
+    const saved = (typeof localStorage !== 'undefined'
+      ? localStorage.getItem(STORAGE_KEY)
+      : null) as ThemeMode | null;
+    const mode = saved ?? 'light';
+    const resolved = resolveMode(mode);
+    applyTheme(resolved);
+    set({ mode, resolved });
+
+    if (mode === 'system') {
+      const mql = window.matchMedia('(prefers-color-scheme: dark)');
+      mql.addEventListener('change', () => {
+        const state = get();
+        if (state.mode === 'system') {
+          const r = getSystemTheme();
+          applyTheme(r);
+          set({ resolved: r });
+        }
+      });
+    }
+  },
+
+  setMode: (mode) => {
+    const resolved = resolveMode(mode);
+    applyTheme(resolved);
+    set({ mode, resolved });
+    try { localStorage.setItem(STORAGE_KEY, mode); } catch {}
+  },
+}));


### PR DESCRIPTION
## Summary

- Convert entire UI from dark-only to light mode default using ~30 CSS custom properties (`:root` light, `.dark` dark)
- Add 3-way theme toggle in Settings (Light / Dark / System) backed by a new Zustand theme store + localStorage persistence
- FOUC prevention via inline `<script>` in `<head>` + `suppressHydrationWarning`
- Fix hardcoded color values (`#1a1a1a`, `rgba(0,0,0,...)`) that didn't adapt to dark mode
- Keep dark: modal backdrops, Toast, RewardReveal (by design)

Closes #76

## Test plan

- [ ] Open app in light mode — all screens should have light backgrounds, dark readable text
- [ ] Toggle to Dark in Settings — all screens revert to dark theme with white/light text
- [ ] Toggle to System — follows device preference
- [ ] Refresh page — theme persists, no flash of wrong theme
- [ ] Check Weekly View, Shop, Check-In, Habit Form, Onboarding, Stats — text readable in both modes
- [ ] RewardReveal and Toast stay dark in both modes
- [ ] Build passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)