### PR TITLE
feat: cars driving on roads

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -413,6 +413,18 @@ population:
   apartment_size_threshold: "defined_per_asset_in_data_file"
 
 # ----------------------------------------------------------------------------
+# CARS (vehicles driving on roads)
+# ----------------------------------------------------------------------------
+cars:
+  max_visible: 20        # max cars rendered at once
+  speed: 1.2             # tiles per second (NPCs are 0.5)
+  scale: 0.55            # visual scale on road tiles
+  idle_min_ms: 200       # min pause at intersections
+  idle_max_ms: 1000      # max pause
+  path_min: 10           # min tiles per drive path
+  path_max: 30           # max tiles per drive path
+
+# ----------------------------------------------------------------------------
 # CITY
 # ----------------------------------------------------------------------------
 city:

--- a/scripts/gen-asset-catalog.js
+++ b/scripts/gen-asset-catalog.js
@@ -68,13 +68,13 @@ function discoverCategory(catConfig) {
 
   if (id === "houses") return discoverHouses();
   if (id === "apartments") return discoverApartments();
+  if (id === "vehicles") return discoverVehicles();
 
   // All other categories: flat directory scan
   const dirMap = {
     public_buildings: "Public",
     restaurants: "Restaurants",
     shopping: "Shopping",
-    vehicles: "Vehicles",
     plants: "Plants",
     decorations: "DecorItems",
     fences: "Fences",
@@ -89,6 +89,38 @@ function discoverCategory(catConfig) {
     name: displayName(stem(f)),
     spriteKey: `${BASE_KEY}/${dirName}/${f}`,
   }));
+}
+
+function discoverVehicles() {
+  const dir = path.join(ASSETS_DIR, "Vehicles");
+  const files = listPngs(dir);
+
+  // Exclusion prefixes — non-road vehicles
+  const excludePrefixes = ["FishingBoat", "RowBoat", "Ship_", "Plane"];
+
+  // Group by base name (strip _Front/_Back suffix)
+  const groups = new Map();
+  for (const f of files) {
+    const s = stem(f);
+    if (excludePrefixes.some((p) => s.startsWith(p))) continue;
+
+    const base = s.replace(/_(Front|Back)$/, "");
+    if (!groups.has(base)) groups.set(base, {});
+    if (s.endsWith("_Front")) groups.get(base).front = f;
+    else if (s.endsWith("_Back")) groups.get(base).back = f;
+  }
+
+  const entries = [];
+  for (const [base, sprites] of groups) {
+    if (!sprites.front) continue; // Need at least a Front sprite
+    entries.push({
+      assetId: `vehicles_${base}`,
+      name: displayName(base),
+      spriteKey: `${BASE_KEY}/Vehicles/${sprites.front}`,
+    });
+  }
+
+  return entries;
 }
 
 function discoverHouses() {

--- a/src/components/ShopAssetCard.tsx
+++ b/src/components/ShopAssetCard.tsx
@@ -6,8 +6,11 @@ import { usePlayerStore } from '@/stores/player-store';
 import { useInventoryStore } from '@/stores/inventory-store';
 import { useShopStore } from '@/stores/shop-store';
 import { useBuildStore } from '@/stores/build-store';
+import { useCarStore } from '@/stores/car-store';
 import { isHouseAsset } from '@/lib/catalog-helpers';
 import { GAME_CONFIG } from '@/config/game-config';
+import { getAllRoadKeys } from '@/engine/road-system';
+import { spawnSingleCar, removeCar } from '@/engine/car-system';
 import PurchaseConfirmDialog from './PurchaseConfirmDialog';
 
 interface Props {
@@ -29,14 +32,52 @@ export default function ShopAssetCard({ asset }: Props) {
   const coins = usePlayerStore((s) => s.coins);
   const ownedAssets = useInventoryStore((s) => s.ownedAssets);
   const newlyUnlockedIds = useShopStore((s) => s.newlyUnlockedIds);
+  const carCount = useCarStore((s) => s.ownedCars.filter((c) => c.assetId === asset.assetId).length);
   const [showConfirm, setShowConfirm] = useState(false);
+  const [showSellOption, setShowSellOption] = useState(false);
 
+  const isVehicle = asset.category === 'vehicles';
   const ownedItem = ownedAssets.find((a) => a.assetId === asset.assetId);
-  const totalOwned = ownedItem ? ownedItem.totalPurchased : 0;
+  const totalOwned = isVehicle ? carCount : (ownedItem ? ownedItem.totalPurchased : 0);
 
   const state = getCardState(asset, playerLevel, coins, totalOwned);
   const isNew = newlyUnlockedIds.has(asset.assetId);
   const isHouse = isHouseAsset(asset);
+
+  const executeVehiclePurchase = useCallback(() => {
+    const success = usePlayerStore.getState().spendCoins(asset.price);
+    if (!success) {
+      useBuildStore.getState().showToast('Not enough coins!');
+      return;
+    }
+
+    if (getAllRoadKeys().length === 0) {
+      usePlayerStore.getState().addCoins(asset.price);
+      useBuildStore.getState().showToast('Build some roads first!');
+      return;
+    }
+
+    const recordId = useCarStore.getState().purchaseCar(asset.assetId);
+    spawnSingleCar(asset.assetId, recordId);
+    useBuildStore.getState().showToast(`${asset.name} deployed to roads!`);
+    if (isNew) {
+      useShopStore.getState().markSeen(asset.assetId);
+    }
+  }, [asset, isNew]);
+
+  const handleSellVehicle = useCallback(() => {
+    const ownedCars = useCarStore.getState().ownedCars
+      .filter((c) => c.assetId === asset.assetId);
+    if (ownedCars.length === 0) return;
+
+    // Sell the oldest one
+    const oldest = ownedCars[0];
+    useCarStore.getState().sellCar(oldest.id);
+    removeCar(oldest.id);
+    usePlayerStore.getState().addCoins(asset.price);
+    useBuildStore.getState().showToast(`Sold ${asset.name} for ${asset.price} coins!`);
+    setShowSellOption(false);
+  }, [asset]);
 
   const executePurchase = useCallback(() => {
     const success = usePlayerStore.getState().spendCoins(asset.price);
@@ -66,6 +107,21 @@ export default function ShopAssetCard({ asset }: Props) {
       return;
     }
 
+    // Vehicles: special purchase flow
+    if (isVehicle) {
+      if (totalOwned > 0) {
+        // Show sell option dialog
+        setShowSellOption(true);
+        return;
+      }
+      if (state === 'cant-afford') {
+        useBuildStore.getState().showToast('Not enough coins!');
+        return;
+      }
+      executeVehiclePurchase();
+      return;
+    }
+
     if (state === 'cant-afford' || state === 'owned-cant-afford') {
       useBuildStore.getState().showToast('Not enough coins!');
       return;
@@ -76,7 +132,7 @@ export default function ShopAssetCard({ asset }: Props) {
     } else {
       executePurchase();
     }
-  }, [asset, state, isHouse, isNew, executePurchase]);
+  }, [asset, state, isHouse, isNew, isVehicle, totalOwned, executePurchase, executeVehiclePurchase]);
 
   const isLocked = state === 'locked';
   const isAffordable = state === 'affordable' || state === 'owned-affordable';
@@ -207,6 +263,101 @@ export default function ShopAssetCard({ asset }: Props) {
           }}
           onCancel={() => setShowConfirm(false)}
         />
+      )}
+
+      {showSellOption && (
+        <div
+          onClick={() => setShowSellOption(false)}
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 160,
+            background: 'rgba(0,0,0,0.4)',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'var(--bg-card)',
+              borderRadius: 16,
+              padding: '20px 24px',
+              maxWidth: 280,
+              width: '90%',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 12,
+              alignItems: 'center',
+            }}
+          >
+            <img
+              src={`/${asset.spriteKey}`}
+              alt={asset.name}
+              style={{ maxWidth: 64, maxHeight: 64, objectFit: 'contain' }}
+            />
+            <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>
+              {asset.name}
+            </span>
+            <span style={{ fontSize: 12, color: 'var(--text-secondary)' }}>
+              Owned: {totalOwned}
+            </span>
+            <div style={{ display: 'flex', gap: 8, width: '100%' }}>
+              {coins >= asset.price && (
+                <button
+                  onClick={() => {
+                    setShowSellOption(false);
+                    executeVehiclePurchase();
+                  }}
+                  style={{
+                    flex: 1,
+                    padding: '10px 0',
+                    borderRadius: 10,
+                    border: 'none',
+                    background: '#2563EB',
+                    color: '#fff',
+                    fontSize: 13,
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                  }}
+                >
+                  Buy ({asset.price})
+                </button>
+              )}
+              <button
+                onClick={handleSellVehicle}
+                style={{
+                  flex: 1,
+                  padding: '10px 0',
+                  borderRadius: 10,
+                  border: '1px solid #DC2626',
+                  background: 'transparent',
+                  color: '#DC2626',
+                  fontSize: 13,
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                }}
+              >
+                Sell (+{asset.price})
+              </button>
+            </div>
+            <button
+              onClick={() => setShowSellOption(false)}
+              style={{
+                padding: '6px 16px',
+                borderRadius: 8,
+                border: '1px solid var(--border-subtle)',
+                background: 'transparent',
+                color: 'var(--text-secondary)',
+                fontSize: 12,
+                cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       )}
     </>
   );

--- a/src/config/game-config.ts
+++ b/src/config/game-config.ts
@@ -116,6 +116,15 @@ export interface GameConfig {
     purchase_confirm_threshold: number;
     house_colors: string[];
   };
+  cars: {
+    max_visible: number;
+    speed: number;
+    scale: number;
+    idle_min_ms: number;
+    idle_max_ms: number;
+    path_min: number;
+    path_max: number;
+  };
 }
 
 export const GAME_CONFIG = rawConfig as GameConfig;

--- a/src/db/city-persistence.ts
+++ b/src/db/city-persistence.ts
@@ -1,4 +1,5 @@
 import { db } from './db';
+import type { CityCar } from './db';
 import type { CameraState } from '../types/camera';
 
 // ---------------------------------------------------------------------------
@@ -100,6 +101,22 @@ export function persistAccessoryBatch(
 
 export function persistAccessoryDeleteBatch(keys: string[]): void {
   db.accessories.bulkDelete(keys).catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Camera persistence — debounced 500ms
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Car persistence — fire-and-forget
+// ---------------------------------------------------------------------------
+
+export function persistCar(record: CityCar): void {
+  db.cars.put(record).catch(() => {});
+}
+
+export function persistCarDelete(id: string): void {
+  db.cars.delete(id).catch(() => {});
 }
 
 // ---------------------------------------------------------------------------

--- a/src/db/city-restore.ts
+++ b/src/db/city-restore.ts
@@ -1,6 +1,6 @@
 import { Assets, Sprite } from 'pixi.js';
 import { db } from './db';
-import type { GameStateRow } from './db';
+import type { GameStateRow, CityCar } from './db';
 import type { SceneContainers } from '../engine/setup-stage';
 import { getAsset } from '../engine/asset-registry';
 import { placeOnGrid } from '../engine/place-on-grid';
@@ -86,6 +86,14 @@ export async function restoreAccessories(): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export { recalcSidewalksAfterRestore };
+
+// ---------------------------------------------------------------------------
+// Restore cars from IndexedDB
+// ---------------------------------------------------------------------------
+
+export async function restoreCars(): Promise<CityCar[]> {
+  return db.cars.toArray();
+}
 
 // ---------------------------------------------------------------------------
 // Restore camera state

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -45,6 +45,13 @@ export interface CityAccessory {
   placedAt: Date;
 }
 
+export interface CityCar {
+  id: string;           // UUID
+  assetId: string;      // e.g. "vehicles_CarType1_Blue"
+  createdAt: string;    // ISO
+  updatedAt: string;    // ISO
+}
+
 export interface GameStateRow {
   id: string;
   cameraX: number;
@@ -69,6 +76,7 @@ const db = new Dexie('habitville') as Dexie & {
   inventory: EntityTable<InventoryItem, 'id'>;
   placedAssets: EntityTable<PlacedAsset, 'id'>;
   weeklySnapshots: EntityTable<WeeklySnapshot, 'id'>;
+  cars: EntityTable<CityCar, 'id'>;
 };
 
 db.version(1).stores({
@@ -124,6 +132,21 @@ db.version(6).stores({
   inventory: 'id, assetId',
   placedAssets: 'id, assetId',
   weeklySnapshots: 'id, weekStart',
+});
+
+db.version(7).stores({
+  city: 'id',
+  roads: 'id',
+  sidewalks: 'id',
+  accessories: 'id',
+  gameState: 'id',
+  habits: 'id, archived',
+  checkIns: 'id, [habitId+date], date',
+  playerProfile: 'id',
+  inventory: 'id, assetId',
+  placedAssets: 'id, assetId',
+  weeklySnapshots: 'id, weekStart',
+  cars: 'id, assetId',
 });
 
 export { db };

--- a/src/engine/asset-loader.ts
+++ b/src/engine/asset-loader.ts
@@ -54,9 +54,15 @@ export async function loadEssentialAssets(
   if (dirt) essentialKeys.add(dirt.textureKey);
 
   // Add textures for saved buildings so restoreCity() works
+  // Keys may be registry keys (resolved via getAsset) or raw texture paths (e.g. car textures)
   for (const assetKey of savedAssetKeys) {
     const asset = getAsset(assetKey);
-    if (asset) essentialKeys.add(asset.textureKey);
+    if (asset) {
+      essentialKeys.add(asset.textureKey);
+    } else {
+      // Treat as a raw texture path (e.g. vehicle Front/Back sprites)
+      essentialKeys.add(assetKey);
+    }
   }
 
   const keys = [...essentialKeys];

--- a/src/engine/asset-registry.ts
+++ b/src/engine/asset-registry.ts
@@ -544,3 +544,16 @@ export function getAssetsByCategory(category: AssetCategory): AssetEntry[] {
 export function getAllAssetKeys(): string[] {
   return [...ASSET_REGISTRY.keys()];
 }
+
+/**
+ * Derive Front/Back texture paths from a merged catalog vehicle assetId.
+ * e.g. "vehicles_CarType1_Blue" → { front: "assets/GiantCityBuilder/Vehicles/CarType1_Blue_Front.png", back: "...Back.png" }
+ */
+export function getVehicleTexturePaths(catalogAssetId: string): { front: string; back: string } | null {
+  if (!catalogAssetId.startsWith('vehicles_')) return null;
+  const baseName = catalogAssetId.replace('vehicles_', '');
+  return {
+    front: `${BASE}/Vehicles/${baseName}_Front.png`,
+    back: `${BASE}/Vehicles/${baseName}_Back.png`,
+  };
+}

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -424,13 +424,17 @@ function updateCars(ticker: Ticker): void {
       car.progress = 0;
       car.idle = false;
 
-      // Capture current visual position as lerp start — no snapping
-      car.fromX = car.sprite.position.x;
-      car.fromY = car.sprite.position.y;
-
       const dir = directionFromDelta(tr - car.currentRow, tc - car.currentCol);
       if (dir !== car.direction) {
         applyDirection(car, dir);
+        // Snap to correct lane for new direction so the car turns in-lane
+        const snapped = carScreenPos(car.currentRow, car.currentCol, car.direction);
+        car.fromX = snapped.x;
+        car.fromY = snapped.y;
+        car.sprite.position.set(snapped.x, snapped.y);
+      } else {
+        car.fromX = car.sprite.position.x;
+        car.fromY = car.sprite.position.y;
       }
     } else {
       car.progress += cfg.speed * dtSec;

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -3,7 +3,7 @@ import type { Ticker } from 'pixi.js';
 import type { SceneContainers } from './setup-stage';
 import { gridToScreen } from './iso-utils';
 import { hasRoad, getAllRoadKeys } from './road-system';
-import { GRID_SIZE, TILE_HEIGHT } from '../config/grid-constants';
+import { GRID_SIZE, TILE_WIDTH, TILE_HEIGHT } from '../config/grid-constants';
 import { GAME_CONFIG } from '../config/game-config';
 import { getVehicleTexturePaths } from './asset-registry';
 import { useCarStore } from '../stores/car-store';
@@ -87,9 +87,24 @@ function directionFromDelta(dRow: number, dCol: number): Direction {
 const CAR_ANCHOR_X = 0.5;   // keep centered so flipX mirrors correctly
 const CAR_ANCHOR_Y = 0.91;  // tire line within the sprite canvas
 
-function carScreenPos(row: number, col: number): { x: number; y: number } {
+// Right-hand traffic: offset cars to the right side of the road.
+// In isometric coords, "right of travel direction" maps to these screen offsets.
+// The offset magnitude is ~25% of the half-tile dimensions to stay in-lane.
+const LANE_OX = TILE_WIDTH * 0.12;   // ~61px lateral offset component
+const LANE_OY = TILE_HEIGHT * 0.12;  // ~35px lateral offset component
+
+// Perpendicular-right screen offset per travel direction (right-hand traffic)
+const LANE_OFFSET: Record<Direction, { x: number; y: number }> = {
+  SE: { x: -LANE_OX, y:  LANE_OY },  // right of SE = toward +row → screen down-left
+  NW: { x:  LANE_OX, y: -LANE_OY },  // right of NW = toward -row → screen up-right
+  SW: { x: -LANE_OX, y: -LANE_OY },  // right of SW = toward -col → screen up-left
+  NE: { x:  LANE_OX, y:  LANE_OY },  // right of NE = toward +col → screen down-right
+};
+
+function carScreenPos(row: number, col: number, dir: Direction): { x: number; y: number } {
   const base = gridToScreen(row, col);
-  return { x: base.x, y: base.y + TILE_HEIGHT / 2 };
+  const lane = LANE_OFFSET[dir];
+  return { x: base.x + lane.x, y: base.y + TILE_HEIGHT / 2 + lane.y };
 }
 
 function tileDepthY(row: number, col: number): number {
@@ -242,7 +257,7 @@ export async function respawnCars(): Promise<void> {
     sprite.anchor.set(CAR_ANCHOR_X, CAR_ANCHOR_Y);
     sprite.scale.set(cfg.scale);
 
-    const screen = carScreenPos(row, col);
+    const screen = carScreenPos(row, col, direction);
     sprite.position.set(screen.x, screen.y);
     (sprite as any)._sortY = tileDepthY(row, col);
 
@@ -293,10 +308,10 @@ export async function spawnSingleCar(assetId: string, recordId: string): Promise
   const direction: Direction = (['SE', 'SW', 'NE', 'NW'] as Direction[])[randomInt(0, 3)];
 
   const sprite = new Sprite(textures.front);
-  sprite.anchor.set(0.5, 1.0);
+  sprite.anchor.set(CAR_ANCHOR_X, CAR_ANCHOR_Y);
   sprite.scale.set(cfg.scale);
 
-  const screen = carScreenPos(row, col);
+  const screen = carScreenPos(row, col, direction);
   sprite.position.set(screen.x, screen.y);
   (sprite as any)._sortY = tileDepthY(row, col);
 
@@ -382,13 +397,13 @@ function updateCars(ticker: Ticker): void {
           ? now + 50
           : now + randomFloat(cfg.idle_min_ms, cfg.idle_max_ms);
 
-        const screen = carScreenPos(car.currentRow, car.currentCol);
+        const screen = carScreenPos(car.currentRow, car.currentCol, car.direction);
         car.sprite.position.set(screen.x, screen.y);
         (car.sprite as any)._sortY = tileDepthY(car.currentRow, car.currentCol);
         needSort = true;
       } else {
-        const from = carScreenPos(car.currentRow, car.currentCol);
-        const to = carScreenPos(car.targetRow, car.targetCol);
+        const from = carScreenPos(car.currentRow, car.currentCol, car.direction);
+        const to = carScreenPos(car.targetRow, car.targetCol, car.direction);
         car.sprite.position.set(
           from.x + (to.x - from.x) * car.progress,
           from.y + (to.y - from.y) * car.progress,

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -1,0 +1,458 @@
+import { Application, Assets, Sprite, Texture } from 'pixi.js';
+import type { Ticker } from 'pixi.js';
+import type { SceneContainers } from './setup-stage';
+import { gridToScreen } from './iso-utils';
+import { hasRoad, getAllRoadKeys } from './road-system';
+import { GRID_SIZE, TILE_HEIGHT } from '../config/grid-constants';
+import { GAME_CONFIG } from '../config/game-config';
+import { getVehicleTexturePaths } from './asset-registry';
+import { useCarStore } from '../stores/car-store';
+import { useBuildStore } from '../stores/build-store';
+import { sortBuildingLayer } from './npc-system';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Direction = 'SE' | 'SW' | 'NE' | 'NW';
+
+interface Car {
+  sprite: Sprite;
+  frontTexture: Texture;
+  backTexture: Texture;
+  assetId: string;
+  recordId: string;
+  currentRow: number;
+  currentCol: number;
+  targetRow: number;
+  targetCol: number;
+  progress: number;     // 0..1
+  direction: Direction;
+  idle: boolean;
+  idleUntil: number;
+  path: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Module state
+// ---------------------------------------------------------------------------
+
+let pixiApp: Application | null = null;
+let sceneContainers: SceneContainers | null = null;
+let cars: Car[] = [];
+let roadGraph: Map<string, string[]> = new Map(); // "r,c" → connected road neighbor keys
+let paused = false;
+let unsubBuildMode: (() => void) | null = null;
+
+// Texture cache: assetId → { front, back }
+const textureCache = new Map<string, { front: Texture; back: Texture }>();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function tileKey(row: number, col: number): string {
+  return `${row},${col}`;
+}
+
+function parseKey(key: string): [number, number] {
+  const [r, c] = key.split(',').map(Number);
+  return [r, c];
+}
+
+function randomInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function randomFloat(min: number, max: number): number {
+  return Math.random() * (max - min) + min;
+}
+
+const CARDINALS: [number, number][] = [
+  [-1, 0], // north
+  [1, 0],  // south
+  [0, -1], // west
+  [0, 1],  // east
+];
+
+function directionFromDelta(dRow: number, dCol: number): Direction {
+  if (dCol > 0) return 'SE'; // grid east  → screen SE
+  if (dRow > 0) return 'SW'; // grid south → screen SW
+  if (dRow < 0) return 'NE'; // grid north → screen NE
+  return 'NW';               // grid west  → screen NW
+}
+
+function carScreenPos(row: number, col: number): { x: number; y: number } {
+  const base = gridToScreen(row, col);
+  return { x: base.x, y: base.y + TILE_HEIGHT / 2 };
+}
+
+function tileDepthY(row: number, col: number): number {
+  return gridToScreen(row, col).y;
+}
+
+// ---------------------------------------------------------------------------
+// Apply direction to sprite (texture swap + flipX)
+// ---------------------------------------------------------------------------
+
+function applyDirection(car: Car, dir: Direction): void {
+  car.direction = dir;
+  switch (dir) {
+    case 'SE': // +col → Front, no flip
+      car.sprite.texture = car.frontTexture;
+      car.sprite.scale.x = Math.abs(car.sprite.scale.x);
+      break;
+    case 'SW': // +row → Front, flipX
+      car.sprite.texture = car.frontTexture;
+      car.sprite.scale.x = -Math.abs(car.sprite.scale.x);
+      break;
+    case 'NE': // -row → Back, flipX
+      car.sprite.texture = car.backTexture;
+      car.sprite.scale.x = -Math.abs(car.sprite.scale.x);
+      break;
+    case 'NW': // -col → Back, no flip
+      car.sprite.texture = car.backTexture;
+      car.sprite.scale.x = Math.abs(car.sprite.scale.x);
+      break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Road graph
+// ---------------------------------------------------------------------------
+
+function buildRoadGraph(): void {
+  roadGraph.clear();
+  const roadKeys = getAllRoadKeys();
+
+  // Populate graph nodes
+  for (const key of roadKeys) {
+    roadGraph.set(key, []);
+  }
+
+  // Connect cardinal neighbors
+  for (const key of roadKeys) {
+    const [row, col] = parseKey(key);
+    const neighbors: string[] = [];
+    for (const [dr, dc] of CARDINALS) {
+      const nk = tileKey(row + dr, col + dc);
+      if (roadGraph.has(nk)) {
+        neighbors.push(nk);
+      }
+    }
+    roadGraph.set(key, neighbors);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Texture loading
+// ---------------------------------------------------------------------------
+
+async function loadCarTextures(assetId: string): Promise<{ front: Texture; back: Texture } | null> {
+  const cached = textureCache.get(assetId);
+  if (cached) return cached;
+
+  const paths = getVehicleTexturePaths(assetId);
+  if (!paths) return null;
+
+  const [front, back] = await Promise.all([
+    Assets.load(paths.front),
+    Assets.load(paths.back),
+  ]);
+
+  const entry = { front, back };
+  textureCache.set(assetId, entry);
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Path generation — random walk along road graph
+// ---------------------------------------------------------------------------
+
+function generatePath(startRow: number, startCol: number): string[] {
+  const cfg = GAME_CONFIG.cars;
+  const path: string[] = [];
+  const steps = randomInt(cfg.path_min, cfg.path_max);
+  let row = startRow;
+  let col = startCol;
+  let prevKey = '';
+
+  for (let i = 0; i < steps; i++) {
+    const key = tileKey(row, col);
+    const neighbors = roadGraph.get(key);
+    if (!neighbors || neighbors.length === 0) break;
+
+    const forward = neighbors.filter((n) => n !== prevKey);
+    const choices = forward.length > 0 ? forward : neighbors;
+
+    const nextKey = choices[randomInt(0, choices.length - 1)];
+    path.push(nextKey);
+    prevKey = key;
+    [row, col] = parseKey(nextKey);
+  }
+
+  return path;
+}
+
+// ---------------------------------------------------------------------------
+// Spawn / Despawn
+// ---------------------------------------------------------------------------
+
+function destroyAllCars(): void {
+  for (const car of cars) {
+    car.sprite.removeFromParent();
+    car.sprite.destroy();
+  }
+  cars = [];
+}
+
+export async function respawnCars(): Promise<void> {
+  if (!sceneContainers) return;
+  destroyAllCars();
+  buildRoadGraph();
+
+  const cfg = GAME_CONFIG.cars;
+  const ownedCars = useCarStore.getState().ownedCars;
+  const roadKeys = Array.from(roadGraph.keys());
+  const count = Math.min(ownedCars.length, cfg.max_visible, roadKeys.length);
+
+  if (count <= 0) return;
+
+  // Shuffle road keys for starting positions
+  const shuffled = roadKeys.sort(() => Math.random() - 0.5);
+
+  // Load textures for all unique assetIds
+  const uniqueAssetIds = [...new Set(ownedCars.slice(0, count).map((c) => c.assetId))];
+  await Promise.all(uniqueAssetIds.map((id) => loadCarTextures(id)));
+
+  for (let i = 0; i < count; i++) {
+    const ownedCar = ownedCars[i];
+    const textures = textureCache.get(ownedCar.assetId);
+    if (!textures) continue;
+
+    const [row, col] = parseKey(shuffled[i % shuffled.length]);
+    const direction: Direction = (['SE', 'SW', 'NE', 'NW'] as Direction[])[randomInt(0, 3)];
+
+    const sprite = new Sprite(textures.front);
+    sprite.anchor.set(0.5, 1.0);
+    sprite.scale.set(cfg.scale);
+
+    const screen = carScreenPos(row, col);
+    sprite.position.set(screen.x, screen.y);
+    (sprite as any)._sortY = tileDepthY(row, col);
+
+    sceneContainers.buildingLayer.addChild(sprite);
+
+    const car: Car = {
+      sprite,
+      frontTexture: textures.front,
+      backTexture: textures.back,
+      assetId: ownedCar.assetId,
+      recordId: ownedCar.id,
+      currentRow: row,
+      currentCol: col,
+      targetRow: row,
+      targetCol: col,
+      progress: 0,
+      direction,
+      idle: true,
+      idleUntil: performance.now() + randomFloat(0, cfg.idle_max_ms),
+      path: [],
+    };
+
+    applyDirection(car, direction);
+    cars.push(car);
+  }
+
+  sortBuildingLayer();
+}
+
+export async function spawnSingleCar(assetId: string, recordId: string): Promise<void> {
+  if (!sceneContainers) return;
+
+  const cfg = GAME_CONFIG.cars;
+
+  // Ensure road graph is current
+  buildRoadGraph();
+  const roadKeys = Array.from(roadGraph.keys());
+  if (roadKeys.length === 0) return;
+
+  // Check max_visible limit
+  if (cars.length >= cfg.max_visible) return;
+
+  const textures = await loadCarTextures(assetId);
+  if (!textures) return;
+
+  const startKey = roadKeys[randomInt(0, roadKeys.length - 1)];
+  const [row, col] = parseKey(startKey);
+  const direction: Direction = (['SE', 'SW', 'NE', 'NW'] as Direction[])[randomInt(0, 3)];
+
+  const sprite = new Sprite(textures.front);
+  sprite.anchor.set(0.5, 1.0);
+  sprite.scale.set(cfg.scale);
+
+  const screen = carScreenPos(row, col);
+  sprite.position.set(screen.x, screen.y);
+  (sprite as any)._sortY = tileDepthY(row, col);
+
+  sceneContainers.buildingLayer.addChild(sprite);
+
+  const car: Car = {
+    sprite,
+    frontTexture: textures.front,
+    backTexture: textures.back,
+    assetId,
+    recordId,
+    currentRow: row,
+    currentCol: col,
+    targetRow: row,
+    targetCol: col,
+    progress: 0,
+    direction,
+    idle: true,
+    idleUntil: performance.now() + randomFloat(0, cfg.idle_max_ms),
+    path: [],
+  };
+
+  applyDirection(car, direction);
+  cars.push(car);
+  sortBuildingLayer();
+}
+
+export function removeCar(recordId: string): void {
+  const idx = cars.findIndex((c) => c.recordId === recordId);
+  if (idx === -1) return;
+
+  const car = cars[idx];
+  car.sprite.removeFromParent();
+  car.sprite.destroy();
+  cars.splice(idx, 1);
+}
+
+// ---------------------------------------------------------------------------
+// Ticker update
+// ---------------------------------------------------------------------------
+
+function updateCars(ticker: Ticker): void {
+  if (paused || cars.length === 0) return;
+
+  const cfg = GAME_CONFIG.cars;
+  const dtSec = ticker.elapsedMS / 1000;
+  const now = performance.now();
+  let needSort = false;
+
+  for (const car of cars) {
+    if (car.idle) {
+      if (now < car.idleUntil) continue;
+
+      if (car.path.length === 0) {
+        car.path = generatePath(car.currentRow, car.currentCol);
+        if (car.path.length === 0) {
+          car.idleUntil = now + randomFloat(cfg.idle_min_ms, cfg.idle_max_ms);
+          continue;
+        }
+      }
+
+      const nextKey = car.path.shift()!;
+      const [tr, tc] = parseKey(nextKey);
+
+      car.targetRow = tr;
+      car.targetCol = tc;
+      car.progress = 0;
+      car.idle = false;
+
+      const dir = directionFromDelta(tr - car.currentRow, tc - car.currentCol);
+      if (dir !== car.direction) {
+        applyDirection(car, dir);
+      }
+    } else {
+      car.progress += cfg.speed * dtSec;
+
+      if (car.progress >= 1) {
+        car.currentRow = car.targetRow;
+        car.currentCol = car.targetCol;
+        car.progress = 0;
+        car.idle = true;
+        car.idleUntil = car.path.length > 0
+          ? now + 50
+          : now + randomFloat(cfg.idle_min_ms, cfg.idle_max_ms);
+
+        const screen = carScreenPos(car.currentRow, car.currentCol);
+        car.sprite.position.set(screen.x, screen.y);
+        (car.sprite as any)._sortY = tileDepthY(car.currentRow, car.currentCol);
+        needSort = true;
+      } else {
+        const from = carScreenPos(car.currentRow, car.currentCol);
+        const to = carScreenPos(car.targetRow, car.targetCol);
+        car.sprite.position.set(
+          from.x + (to.x - from.x) * car.progress,
+          from.y + (to.y - from.y) * car.progress,
+        );
+        (car.sprite as any)._sortY = Math.max(
+          tileDepthY(car.currentRow, car.currentCol),
+          tileDepthY(car.targetRow, car.targetCol),
+        );
+        needSort = true;
+      }
+    }
+  }
+
+  if (needSort) sortBuildingLayer();
+}
+
+// ---------------------------------------------------------------------------
+// Build mode lifecycle
+// ---------------------------------------------------------------------------
+
+function onBuildModeChange(buildMode: boolean): void {
+  if (buildMode) {
+    paused = true;
+    for (const car of cars) {
+      car.sprite.visible = false;
+    }
+  } else {
+    paused = false;
+    respawnCars().catch((err) => console.error('[Car] respawn failed:', err));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Init / Destroy
+// ---------------------------------------------------------------------------
+
+let prevBuildMode = false;
+
+export function initCarSystem(app: Application, containers: SceneContainers): void {
+  pixiApp = app;
+  sceneContainers = containers;
+  paused = false;
+
+  app.ticker.add(updateCars);
+
+  prevBuildMode = useBuildStore.getState().buildMode;
+  unsubBuildMode = useBuildStore.subscribe((state) => {
+    if (prevBuildMode !== state.buildMode) {
+      onBuildModeChange(state.buildMode);
+    }
+    prevBuildMode = state.buildMode;
+  });
+}
+
+export function destroyCarSystem(): void {
+  if (pixiApp) {
+    pixiApp.ticker.remove(updateCars);
+  }
+
+  if (unsubBuildMode) {
+    unsubBuildMode();
+    unsubBuildMode = null;
+  }
+
+  destroyAllCars();
+  textureCache.clear();
+  roadGraph.clear();
+
+  pixiApp = null;
+  sceneContainers = null;
+  paused = false;
+}

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -388,6 +388,9 @@ function updateCars(ticker: Ticker): void {
       const dir = directionFromDelta(tr - car.currentRow, tc - car.currentCol);
       if (dir !== car.direction) {
         applyDirection(car, dir);
+        // Snap position to new lane offset immediately so there's no visual pop
+        const screen = carScreenPos(car.currentRow, car.currentCol, car.direction);
+        car.sprite.position.set(screen.x, screen.y);
       }
     } else {
       car.progress += cfg.speed * dtSec;
@@ -398,7 +401,7 @@ function updateCars(ticker: Ticker): void {
         car.progress = 0;
         car.idle = true;
         car.idleUntil = car.path.length > 0
-          ? now + 50
+          ? now   // no pause between path steps — seamless driving
           : now + randomFloat(cfg.idle_min_ms, cfg.idle_max_ms);
 
         const screen = carScreenPos(car.currentRow, car.currentCol, car.direction);

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -103,7 +103,7 @@ const LANE_OFFSET: Record<Direction, { x: number; y: number }> = {
 
 // Extra downward nudge so the tire line sits on the visual road surface
 // rather than at the geometric diamond center (which is too high visually).
-const CAR_Y_NUDGE = TILE_HEIGHT * 0.18; // ~53px down
+const CAR_Y_NUDGE = TILE_HEIGHT * 0.35; // ~102px down
 
 function carScreenPos(row: number, col: number, dir: Direction): { x: number; y: number } {
   const base = gridToScreen(row, col);

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -82,6 +82,11 @@ function directionFromDelta(dRow: number, dCol: number): Direction {
   return 'NW';               // grid west  → screen NW
 }
 
+// Anchor tuned to average content bounds across all 45 vehicle sprites:
+// content center-x ≈ 0.526, content bottom (tire line) ≈ 0.911
+const CAR_ANCHOR_X = 0.5;   // keep centered so flipX mirrors correctly
+const CAR_ANCHOR_Y = 0.91;  // tire line within the sprite canvas
+
 function carScreenPos(row: number, col: number): { x: number; y: number } {
   const base = gridToScreen(row, col);
   return { x: base.x, y: base.y + TILE_HEIGHT / 2 };
@@ -234,7 +239,7 @@ export async function respawnCars(): Promise<void> {
     const direction: Direction = (['SE', 'SW', 'NE', 'NW'] as Direction[])[randomInt(0, 3)];
 
     const sprite = new Sprite(textures.front);
-    sprite.anchor.set(0.5, 1.0);
+    sprite.anchor.set(CAR_ANCHOR_X, CAR_ANCHOR_Y);
     sprite.scale.set(cfg.scale);
 
     const screen = carScreenPos(row, col);

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -101,10 +101,14 @@ const LANE_OFFSET: Record<Direction, { x: number; y: number }> = {
   NE: { x:  LANE_OX, y:  LANE_OY },  // right of NE = toward +col → screen down-right
 };
 
+// Extra downward nudge so the tire line sits on the visual road surface
+// rather than at the geometric diamond center (which is too high visually).
+const CAR_Y_NUDGE = TILE_HEIGHT * 0.18; // ~53px down
+
 function carScreenPos(row: number, col: number, dir: Direction): { x: number; y: number } {
   const base = gridToScreen(row, col);
   const lane = LANE_OFFSET[dir];
-  return { x: base.x + lane.x, y: base.y + TILE_HEIGHT / 2 + lane.y };
+  return { x: base.x + lane.x, y: base.y + TILE_HEIGHT / 2 + CAR_Y_NUDGE + lane.y };
 }
 
 function tileDepthY(row: number, col: number): number {

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -3,7 +3,7 @@ import type { Ticker } from 'pixi.js';
 import type { SceneContainers } from './setup-stage';
 import { gridToScreen } from './iso-utils';
 import { hasRoad, getAllRoadKeys } from './road-system';
-import { GRID_SIZE, TILE_WIDTH, TILE_HEIGHT } from '../config/grid-constants';
+import { TILE_WIDTH, TILE_HEIGHT } from '../config/grid-constants';
 import { GAME_CONFIG } from '../config/game-config';
 import { getVehicleTexturePaths } from './asset-registry';
 import { useCarStore } from '../stores/car-store';
@@ -103,6 +103,11 @@ const LANE_OFFSET: Record<Direction, { x: number; y: number }> = {
   NE: { x:  LANE_OX, y:  LANE_OY },  // right of NE = toward +col → screen down-right
 };
 
+// Depth sort bias: cars sort half a tile behind their actual grid position.
+// This ensures ground-level cars render behind tall buildings at the same
+// or diagonally adjacent tile depth (e.g. road at (r-1,c+1) vs building at (r,c)).
+const CAR_SORT_BIAS = -TILE_HEIGHT / 2;
+
 // Extra downward nudge so the tire line sits on the visual road surface
 // rather than at the geometric diamond center (which is too high visually).
 const CAR_Y_NUDGE = TILE_HEIGHT * 0.35; // ~102px down
@@ -111,10 +116,6 @@ function carScreenPos(row: number, col: number, dir: Direction): { x: number; y:
   const base = gridToScreen(row, col);
   const lane = LANE_OFFSET[dir];
   return { x: base.x + lane.x, y: base.y + TILE_HEIGHT / 2 + CAR_Y_NUDGE + lane.y };
-}
-
-function tileDepthY(row: number, col: number): number {
-  return gridToScreen(row, col).y;
 }
 
 // ---------------------------------------------------------------------------
@@ -265,7 +266,7 @@ export async function respawnCars(): Promise<void> {
 
     const screen = carScreenPos(row, col, direction);
     sprite.position.set(screen.x, screen.y);
-    (sprite as any)._sortY = tileDepthY(row, col);
+    (sprite as any)._sortY = gridToScreen(row, col).y + CAR_SORT_BIAS;
 
     sceneContainers.buildingLayer.addChild(sprite);
 
@@ -321,7 +322,7 @@ export async function spawnSingleCar(assetId: string, recordId: string): Promise
 
   const screen = carScreenPos(row, col, direction);
   sprite.position.set(screen.x, screen.y);
-  (sprite as any)._sortY = tileDepthY(row, col);
+  (sprite as any)._sortY = gridToScreen(row, col).y + CAR_SORT_BIAS;
 
   sceneContainers.buildingLayer.addChild(sprite);
 
@@ -415,18 +416,17 @@ function updateCars(ticker: Ticker): void {
         car.sprite.position.set(screen.x, screen.y);
         car.fromX = screen.x;
         car.fromY = screen.y;
-        (car.sprite as any)._sortY = tileDepthY(car.currentRow, car.currentCol);
+        (car.sprite as any)._sortY = gridToScreen(car.currentRow, car.currentCol).y + CAR_SORT_BIAS;
         needSort = true;
       } else {
         const to = carScreenPos(car.targetRow, car.targetCol, car.direction);
-        car.sprite.position.set(
-          car.fromX + (to.x - car.fromX) * car.progress,
-          car.fromY + (to.y - car.fromY) * car.progress,
-        );
-        (car.sprite as any)._sortY = Math.max(
-          tileDepthY(car.currentRow, car.currentCol),
-          tileDepthY(car.targetRow, car.targetCol),
-        );
+        const lerpX = car.fromX + (to.x - car.fromX) * car.progress;
+        const lerpY = car.fromY + (to.y - car.fromY) * car.progress;
+        car.sprite.position.set(lerpX, lerpY);
+        // Smoothly interpolate depth between current and target tile
+        const fromDepth = gridToScreen(car.currentRow, car.currentCol).y;
+        const toDepth = gridToScreen(car.targetRow, car.targetCol).y;
+        (car.sprite as any)._sortY = fromDepth + (toDepth - fromDepth) * car.progress + CAR_SORT_BIAS;
         needSort = true;
       }
     }

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -84,6 +84,14 @@ function directionFromDelta(dRow: number, dCol: number): Direction {
   return 'NW';               // grid west  → screen NW
 }
 
+// Grid delta per direction (for path generation straight-line preference)
+const DIR_DELTA: Record<Direction, [number, number]> = {
+  SE: [0, 1],   // +col
+  SW: [1, 0],   // +row
+  NE: [-1, 0],  // -row
+  NW: [0, -1],  // -col
+};
+
 // Anchor tuned to average content bounds across all 45 vehicle sprites:
 // content center-x ≈ 0.526, content bottom (tire line) ≈ 0.911
 const CAR_ANCHOR_X = 0.5;   // keep centered so flipX mirrors correctly
@@ -196,26 +204,50 @@ async function loadCarTextures(assetId: string): Promise<{ front: Texture; back:
 // Path generation — random walk along road graph
 // ---------------------------------------------------------------------------
 
-function generatePath(startRow: number, startCol: number): string[] {
+function generatePath(startRow: number, startCol: number, lastDir?: Direction): string[] {
   const cfg = GAME_CONFIG.cars;
   const path: string[] = [];
   const steps = randomInt(cfg.path_min, cfg.path_max);
   let row = startRow;
   let col = startCol;
+
+  // Derive the "came from" key from last travel direction so first step doesn't U-turn
   let prevKey = '';
+  if (lastDir) {
+    const delta = DIR_DELTA[lastDir];
+    // The tile we "came from" is opposite of travel direction
+    prevKey = tileKey(row - delta[0], col - delta[1]);
+  }
+
+  // Track current movement delta for straight-line preference
+  let dRow = lastDir ? DIR_DELTA[lastDir][0] : 0;
+  let dCol = lastDir ? DIR_DELTA[lastDir][1] : 0;
 
   for (let i = 0; i < steps; i++) {
     const key = tileKey(row, col);
     const neighbors = roadGraph.get(key);
     if (!neighbors || neighbors.length === 0) break;
 
+    // Never go back to the tile we just came from
     const forward = neighbors.filter((n) => n !== prevKey);
     const choices = forward.length > 0 ? forward : neighbors;
 
-    const nextKey = choices[randomInt(0, choices.length - 1)];
+    // Prefer continuing straight: if the straight-ahead tile is available, take it 80% of the time
+    let nextKey: string;
+    const straightKey = (dRow !== 0 || dCol !== 0) ? tileKey(row + dRow, col + dCol) : '';
+    if (straightKey && choices.includes(straightKey) && choices.length > 1 && Math.random() < 0.8) {
+      nextKey = straightKey;
+    } else {
+      nextKey = choices[randomInt(0, choices.length - 1)];
+    }
+
     path.push(nextKey);
     prevKey = key;
-    [row, col] = parseKey(nextKey);
+    const [nr, nc] = parseKey(nextKey);
+    dRow = nr - row;
+    dCol = nc - col;
+    row = nr;
+    col = nc;
   }
 
   return path;
@@ -377,7 +409,7 @@ function updateCars(ticker: Ticker): void {
       if (now < car.idleUntil) continue;
 
       if (car.path.length === 0) {
-        car.path = generatePath(car.currentRow, car.currentCol);
+        car.path = generatePath(car.currentRow, car.currentCol, car.direction);
         if (car.path.length === 0) {
           car.idleUntil = now + randomFloat(cfg.idle_min_ms, cfg.idle_max_ms);
           continue;

--- a/src/engine/car-system.ts
+++ b/src/engine/car-system.ts
@@ -31,6 +31,8 @@ interface Car {
   idle: boolean;
   idleUntil: number;
   path: string[];
+  fromX: number;       // lerp start — captured from actual sprite position
+  fromY: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -282,6 +284,8 @@ export async function respawnCars(): Promise<void> {
       idle: true,
       idleUntil: performance.now() + randomFloat(0, cfg.idle_max_ms),
       path: [],
+      fromX: screen.x,
+      fromY: screen.y,
     };
 
     applyDirection(car, direction);
@@ -336,6 +340,8 @@ export async function spawnSingleCar(assetId: string, recordId: string): Promise
     idle: true,
     idleUntil: performance.now() + randomFloat(0, cfg.idle_max_ms),
     path: [],
+    fromX: screen.x,
+    fromY: screen.y,
   };
 
   applyDirection(car, direction);
@@ -385,12 +391,13 @@ function updateCars(ticker: Ticker): void {
       car.progress = 0;
       car.idle = false;
 
+      // Capture current visual position as lerp start — no snapping
+      car.fromX = car.sprite.position.x;
+      car.fromY = car.sprite.position.y;
+
       const dir = directionFromDelta(tr - car.currentRow, tc - car.currentCol);
       if (dir !== car.direction) {
         applyDirection(car, dir);
-        // Snap position to new lane offset immediately so there's no visual pop
-        const screen = carScreenPos(car.currentRow, car.currentCol, car.direction);
-        car.sprite.position.set(screen.x, screen.y);
       }
     } else {
       car.progress += cfg.speed * dtSec;
@@ -406,14 +413,15 @@ function updateCars(ticker: Ticker): void {
 
         const screen = carScreenPos(car.currentRow, car.currentCol, car.direction);
         car.sprite.position.set(screen.x, screen.y);
+        car.fromX = screen.x;
+        car.fromY = screen.y;
         (car.sprite as any)._sortY = tileDepthY(car.currentRow, car.currentCol);
         needSort = true;
       } else {
-        const from = carScreenPos(car.currentRow, car.currentCol, car.direction);
         const to = carScreenPos(car.targetRow, car.targetCol, car.direction);
         car.sprite.position.set(
-          from.x + (to.x - from.x) * car.progress,
-          from.y + (to.y - from.y) * car.progress,
+          car.fromX + (to.x - car.fromX) * car.progress,
+          car.fromY + (to.y - car.fromY) * car.progress,
         );
         (car.sprite as any)._sortY = Math.max(
           tileDepthY(car.currentRow, car.currentCol),

--- a/src/engine/game.ts
+++ b/src/engine/game.ts
@@ -23,6 +23,10 @@ import { roadAssetKey } from './road-tiles';
 import { sidewalkAssetKey } from './sidewalk-tiles';
 import { initSidewalkSystem, destroySidewalkSystem } from './sidewalk-system';
 import { initNpcSystem, destroyNpcSystem, respawnNPCs } from './npc-system';
+import { initCarSystem, destroyCarSystem, respawnCars } from './car-system';
+import { getVehicleTexturePaths } from './asset-registry';
+import { restoreCars } from '../db/city-restore';
+import { useCarStore } from '../stores/car-store';
 
 let app: Application | null = null;
 let containers: SceneContainers | null = null;
@@ -40,18 +44,33 @@ async function doInitGame(): Promise<HTMLCanvasElement> {
   app = await createApp();
   containers = setupStage(app);
 
-  // Load essential assets (grid tiles + saved buildings + saved roads + sidewalks + accessories)
-  const [savedBuildings, savedRoads, savedSidewalks, savedAccessories] = await Promise.all([
+  // Load essential assets (grid tiles + saved buildings + saved roads + sidewalks + accessories + car textures)
+  const [savedBuildings, savedRoads, savedSidewalks, savedAccessories, savedCars] = await Promise.all([
     db.city.toArray(),
     db.roads.toArray(),
     db.sidewalks.toArray(),
     db.accessories.toArray(),
+    restoreCars(),
   ]);
+
+  // Derive car texture paths from owned car records
+  const carTexturePaths: string[] = [];
+  const seenCarAssets = new Set<string>();
+  for (const car of savedCars) {
+    if (seenCarAssets.has(car.assetId)) continue;
+    seenCarAssets.add(car.assetId);
+    const paths = getVehicleTexturePaths(car.assetId);
+    if (paths) {
+      carTexturePaths.push(paths.front, paths.back);
+    }
+  }
+
   const savedAssetKeys = [...new Set([
     ...savedBuildings.map((b) => b.assetKey),
     ...savedRoads.map((r) => roadAssetKey(r.roadType, r.tileNum)),
     ...savedSidewalks.map((s) => sidewalkAssetKey(s.tileNum)),
     ...savedAccessories.map((a) => a.assetKey),
+    ...carTexturePaths,
   ])];
   await loadEssentialAssets(savedAssetKeys, (progress) => {
     const bar = document.getElementById('loading-progress');
@@ -96,12 +115,18 @@ async function doInitGame(): Promise<HTMLCanvasElement> {
   initNpcSystem(app, containers);
   respawnNPCs().catch((err) => console.error('[NPC] initial spawn failed:', err));
 
+  // Car system: init and spawn cars from saved records
+  initCarSystem(app, containers);
+  useCarStore.getState().initFromRecords(savedCars);
+  respawnCars().catch((err) => console.error('[Car] initial spawn failed:', err));
+
   return app.canvas;
 }
 
 export function destroyGame(): void {
   if (!app) return;
 
+  destroyCarSystem();
   destroyNpcSystem();
   destroyBuildSystem();
   destroySidewalkSystem();

--- a/src/engine/npc-system.ts
+++ b/src/engine/npc-system.ts
@@ -321,7 +321,7 @@ export async function respawnNPCs(): Promise<void> {
   sortBuildingLayer();
 }
 
-function sortBuildingLayer(): void {
+export function sortBuildingLayer(): void {
   if (!sceneContainers) return;
   sceneContainers.buildingLayer.children.sort((a, b) => {
     const ay = (a as any)._sortY ?? a.position.y;

--- a/src/engine/road-system.ts
+++ b/src/engine/road-system.ts
@@ -61,6 +61,10 @@ export function hasRoad(row: number, col: number): boolean {
   return roadMap.has(tileKey(row, col));
 }
 
+export function getAllRoadKeys(): string[] {
+  return Array.from(roadMap.keys());
+}
+
 /** Used by computeBitmask — returns roadType at (r,c) or undefined */
 function getRoadTypeAt(r: number, c: number): string | undefined {
   return roadMap.get(tileKey(r, c))?.roadType;

--- a/src/lib/catalog-helpers.ts
+++ b/src/lib/catalog-helpers.ts
@@ -53,8 +53,8 @@ export function catalogToRegistryKey(catalogAssetId: string, color?: string): st
       return catalogAssetId.replace('fences_', '');
     }
     case 'vehicles': {
-      // vehicles_Bus_Grey_Back -> Bus_Grey_Back
-      return catalogAssetId.replace('vehicles_', '');
+      // vehicles_CarType1_Blue -> CarType1_Blue_Front (show Front sprite for display)
+      return catalogAssetId.replace('vehicles_', '') + '_Front';
     }
     case 'apartments': {
       // apartments_Appartment_Blue_1x1_Level1 -> Appartment_Blue_1x1_Level1

--- a/src/stores/car-store.ts
+++ b/src/stores/car-store.ts
@@ -1,0 +1,46 @@
+import { create } from 'zustand';
+import type { CityCar } from '@/db/db';
+import { persistCar, persistCarDelete } from '@/db/city-persistence';
+
+interface CarState {
+  ownedCars: CityCar[];
+  initialized: boolean;
+
+  initFromRecords: (records: CityCar[]) => void;
+  purchaseCar: (assetId: string) => string;   // returns record ID
+  sellCar: (recordId: string) => void;
+  getCountByAssetId: (assetId: string) => number;
+}
+
+export const useCarStore = create<CarState>((set, get) => ({
+  ownedCars: [],
+  initialized: false,
+
+  initFromRecords: (records) => {
+    set({ ownedCars: records, initialized: true });
+  },
+
+  purchaseCar: (assetId) => {
+    const now = new Date().toISOString();
+    const record: CityCar = {
+      id: crypto.randomUUID(),
+      assetId,
+      createdAt: now,
+      updatedAt: now,
+    };
+    set((s) => ({ ownedCars: [...s.ownedCars, record] }));
+    persistCar(record);
+    return record.id;
+  },
+
+  sellCar: (recordId) => {
+    set((s) => ({
+      ownedCars: s.ownedCars.filter((c) => c.id !== recordId),
+    }));
+    persistCarDelete(recordId);
+  },
+
+  getCountByAssetId: (assetId) => {
+    return get().ownedCars.filter((c) => c.assetId === assetId).length;
+  },
+}));


### PR DESCRIPTION
## Summary
- Purchased vehicles now automatically appear **driving on roads** instead of going into inventory as static decorations
- Cars drive on the **right side** of the road (right-hand traffic) with proper lane offsets
- Front/Back vehicle sprites merged into single shop entries (45 items, down from 101)
- Buy/sell vehicles directly from the shop — no inventory step
- Cars correctly depth-sort behind buildings, drive straight with 80% preference, and snap to correct lane on turns

## Changes
- **New files:** `src/engine/car-system.ts` (movement, rendering, lifecycle), `src/stores/car-store.ts` (Zustand store)
- **Catalog:** Merged Front/Back pairs, excluded boats/ships/plane from shop
- **Config:** Added `cars` tuning section (speed, scale, max_visible, idle timing, path length)
- **DB:** New `cars` table (version 7) with persistence helpers
- **Shop:** Vehicle purchase skips inventory, spawns car immediately; sell dialog with full refund
- **Engine:** Road graph pathfinding, right-hand lane offsets, tile-based depth sort with bias, smooth visual lerp

## Test plan
- [ ] Open shop → Vehicles tab shows merged entries (e.g. "Car Type1 Blue" not "Car Type1 Blue Front")
- [ ] Purchase a car with roads → car immediately appears driving on a road
- [ ] Purchase a car with NO roads → "Build some roads first!" toast, coins refunded
- [ ] Cars drive on the right side of the road, opposite-direction cars use opposite lanes
- [ ] Cars drive straight on roads, only occasionally turn at intersections
- [ ] Cars render behind buildings when passing behind them
- [ ] Enter build mode → cars disappear; exit → cars reappear
- [ ] Reload page → owned cars respawn on roads
- [ ] Tap owned vehicle in shop → sell option with full refund, car removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)